### PR TITLE
RFC: Added a function to list all prime factors with multiplicity

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ Dict{Int64,Int64} with 2 entries:
   5 => 2
 > ```
 
+    factorvec(n::Integer) -> Vector
+
+> Compute the prime factorization of `n` with multiplicities. Returns a vector with
+the same type as `n`. The product of the returned vector will equal `n`.
+
+> ```julia
+julia> factorvec(100)
+4-element Array{Int64,1}:
+ 2
+ 2
+ 5
+ 5
+> ```
+
     isprime(x::Integer) -> Bool
 
 > Returns `true` if `x` is prime, and `false` otherwise.

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -209,7 +209,7 @@ Dict{Int64,Int64} with 2 entries:
 ```
 """
 function factor{T<:Integer}(n::T)
-    0 < n || throw(ArgumentError("number to be factored must be > 0, got $n"))
+    0 < n || throw(ArgumentError("number to be factored must be ≥ 0, got $n"))
     h = Dict{T,Int}()
     n == 1 && return h
     isprime(n) && (h[n] = 1; return h)

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -108,7 +108,7 @@ function primes(lo::Int, hi::Int)
     lo ≤ 3 ≤ hi && push!(list, 3)
     lo ≤ 5 ≤ hi && push!(list, 5)
     hi < 7 && return list
-    sizehint!(list,  5 + floor(Int, hi / (log(hi) - 1.12) -  lo / (log(max(lo,2)) - 1.12*(lo > 7))) ) # http://projecteuclid.org/euclid.rmjm/1181070157    
+    sizehint!(list,  5 + floor(Int, hi / (log(hi) - 1.12) -  lo / (log(max(lo,2)) - 1.12*(lo > 7))) ) # http://projecteuclid.org/euclid.rmjm/1181070157
     sieve = _primesmask(max(7, lo), hi)
     lwi = wheel_index(lo - 1)
     @inbounds for i = 1:length(sieve)   # don't use eachindex here
@@ -209,7 +209,7 @@ Dict{Int64,Int64} with 2 entries:
 ```
 """
 function factor{T<:Integer}(n::T)
-    0 < n || throw(ArgumentError("number to be factored must be ≥ 0, got $n"))
+    0 < n || throw(ArgumentError("number to be factored must be > 0, got $n"))
     h = Dict{T,Int}()
     n == 1 && return h
     isprime(n) && (h[n] = 1; return h)
@@ -268,6 +268,16 @@ function pollardfactors!{T<:Integer,K<:Integer}(n::T, h::Dict{K,Int})
             isprime(G2) ? h[G2] = get(h,G2,0) + 1 : pollardfactors!(G2,h)
             return h
         end
+    end
+end
+
+function factorize{T<:Integer}(n::T)
+    if n < 1
+        throw(ArgumentError("number to be factored must be > 0, got $n"))
+    elseif n == 1
+        return Vector{T}(0)  # For consistency with factor(1)
+    else
+        return mapreduce(collect, vcat, [repeated(k,v) for (k,v) in factor(n)])
     end
 end
 

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -5,7 +5,7 @@ if VERSION >= v"0.5.0-dev+4340"
     if isdefined(Base,:isprime)
         import Base: isprime, primes, primesmask, factor
     else
-        export isprime, primes, primesmask, factor
+        export isprime, primes, primesmask, factor, factorvec
     end
 end
 
@@ -271,7 +271,22 @@ function pollardfactors!{T<:Integer,K<:Integer}(n::T, h::Dict{K,Int})
     end
 end
 
-function factorize{T<:Integer}(n::T)
+"""
+    factorvec(n::Integer) -> Vector
+
+Compute the prime factorization of `n` with multiplicities. Returns a vector with
+the same type as `n`. The product of the returned vector will equal `n`.
+
+```jldoctest
+julia> factorvec(100)
+4-element Array{Int64,1}:
+ 2
+ 2
+ 5
+ 5
+```
+"""
+function factorvec{T<:Integer}(n::T)
     if n < 1
         throw(ArgumentError("number to be factored must be > 0, got $n"))
     elseif n == 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Primes
 using Base.Test
 
-import Primes: isprime, primes, primesmask, factor
+import Primes: isprime, primes, primesmask, factor, factorize
 
 # primes
 
@@ -203,3 +203,9 @@ euler7(n) = primes(floor(Int,n*log(n*log(n))))[n]
 
 # project euler 10: 142913828922
 @test sum(map(Int64,primes(2000000))) == 142913828922
+
+# factorize
+@test_throws ArgumentError factorize(0)
+@test factorize(1) == Int[]
+@test factorize(3) == [3]
+@test factorize(4) == [2,2]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Primes
 using Base.Test
 
-import Primes: isprime, primes, primesmask, factor, factorize
+import Primes: isprime, primes, primesmask, factor, factorvec
 
 # primes
 
@@ -204,8 +204,8 @@ euler7(n) = primes(floor(Int,n*log(n*log(n))))[n]
 # project euler 10: 142913828922
 @test sum(map(Int64,primes(2000000))) == 142913828922
 
-# factorize
-@test_throws ArgumentError factorize(0)
-@test factorize(1) == Int[]
-@test factorize(3) == [3]
-@test factorize(4) == [2,2]
+# factorvec
+@test_throws ArgumentError factorvec(0)
+@test factorvec(1) == Int[]
+@test factorvec(3) == [3]
+@test factorvec(4) == [2,2]


### PR DESCRIPTION
Sometimes it's nice to be able to have an array with *all* of the prime factors of a number. This PR introduces a convenience function `factorize` that does just that.
```julia
julia> factorize(4)
2-element Array{Int64,1}:
 2
 2
```
This reshapes the output from
```julia
julia> factor(4)
Dict{Int64,Int64} with 1 entry:
  2 => 2
```
Since it's essentially collecting a dictionary, there's *no guaranteed order* to the output array, other than the fact that the runs of primes are grouped. I don't know whether that's an issue.

Does this seem like a useful function to include in the package?