### PR TITLE
Miscellaneous cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ Julia functions for computing prime numbers.
 
 ## Usage
 
-At the moment, this repository just contains the following functions which have been duplicated from Base Julia:
+This repository contains some functions relating to prime numbers which have been duplicated from Base Julia, as well as new functions and improvements.
 
-    factor(n) -> Dict
+    factor(n) -> DataStructures.SortedDict
 
-> Compute the prime factorization of an integer `n`. Returns a dictionary. The keys of the
-dictionary correspond to the factors, and hence are of the same type as `n`. The value
-associated with each key indicates the number of times the factor appears in the
+> Compute the prime factorization of an integer `n`. Returns a sorted dictionary. The
+keys of the dictionary correspond to the factors, and hence are of the same type as `n`.
+The value associated with each key indicates the number of times the factor appears in the
 factorization.
 > ```julia
 julia> factor(100) # == 2*2*5*5
-Dict{Int64,Int64} with 2 entries:
+DataStructures.SortedDict{Int64,Int64,Base.Order.ForwardOrdering} with 2 entries:
   2 => 2
   5 => 2
 > ```
@@ -70,4 +70,4 @@ up to `hi`. Useful when working with either primes or composite numbers.
 To avoid naming conflicts with Base, these are not exported for Julia version 0.4. In this case you will need to explicitly import the symbols:
 
     using Primes
-    import Primes: isprime, primes, primesmask, factor
+    import Primes: isprime, primes, primesmask, factor, factorvec

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -223,22 +223,22 @@ isprime(n::Int128) = n < 2 ? false :
 #     http://maths-people.anu.edu.au/~brent/pub/pub051.html
 #
 """
-    factor(n) -> SortedDict
+    factor(n) -> DataStructures.SortedDict
 
-Compute the prime factorization of an integer `n`. Returns a dictionary. The keys of the
-dictionary correspond to the factors, and hence are of the same type as `n`. The value
-associated with each key indicates the number of times the factor appears in the
+Compute the prime factorization of an integer `n`. Returns a sorted dictionary. The
+keys of the dictionary correspond to the factors, and hence are of the same type as `n`.
+The value associated with each key indicates the number of times the factor appears in the
 factorization.
 
 ```jldoctest
 julia> factor(100) # == 2*2*5*5
-Dict{Int64,Int64} with 2 entries:
+DataStructures.SortedDict{Int64,Int64,Base.Order.ForwardOrdering} with 2 entries:
   2 => 2
   5 => 2
 ```
 """
 function factor{T<:Integer}(n::T)
-    0 < n || throw(ArgumentError("number to be factored must be ≥ 0, got $n"))
+    0 < n || throw(ArgumentError("number to be factored must be > 0, got $n"))
     h = SortedDict{T,Int,Base.Order.ForwardOrdering}()
     n == 1 && return h
     isprime(n) && (h[n] = 1; return h)


### PR DESCRIPTION
Since `factorvec` is now part of the repo and this functionality is not from Base, I reworded the initial paragraph under Usage. It also wasn't included in the part of the docs that says what to import so I added it there too.

I also updated the `factor` docs both in the README and the source docstring, and corrected a little white lie that `factor`'s `ArgumentError` was telling about what constitutes valid input. (Should have been > 0, not ≥ 0.)