### PR TITLE
choose the container holding the factors via an argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,26 +12,36 @@ Julia functions for computing prime numbers.
 
 This repository contains some functions relating to prime numbers which have been duplicated from Base Julia, as well as new functions and improvements.
 
-    factor(n) -> DataStructures.SortedDict
+    factor(n) -> Dict
 
-> Compute the prime factorization of an integer `n`. Returns a sorted dictionary. The
+> Compute the prime factorization of an integer `n`. Returns a dictionary. The
 keys of the dictionary correspond to the factors, and hence are of the same type as `n`.
 The value associated with each key indicates the number of times the factor appears in the
 factorization.
 > ```julia
 julia> factor(100) # == 2*2*5*5
+Dict{Int64,Int64} with 2 entries:
+  2 => 2
+  5 => 2
+> ```
+
+    factor(ContainerType, n) -> ContainerType
+
+> Return the factorization of `n` using ContainerType
+(a subtype of `Associative` or `AbstractArray`).
+
+> ```julia
+julia> factor(DataStructures.SortedDict, 100)
 DataStructures.SortedDict{Int64,Int64,Base.Order.ForwardOrdering} with 2 entries:
   2 => 2
   5 => 2
 > ```
 
-    factorvec(n::Integer) -> Vector
-
-> Compute the prime factorization of `n` with multiplicities. Returns a vector with
-the same type as `n`. The product of the returned vector will equal `n`.
+> When `ContainerType <: AbstractArray`, this returns the list
+of all prime factors of `n` with multiplicities, in sorted order.
 
 > ```julia
-julia> factorvec(100)
+julia> factor(Vector, 100)
 4-element Array{Int64,1}:
  2
  2
@@ -70,4 +80,4 @@ up to `hi`. Useful when working with either primes or composite numbers.
 To avoid naming conflicts with Base, these are not exported for Julia version 0.4. In this case you will need to explicitly import the symbols:
 
     using Primes
-    import Primes: isprime, primes, primesmask, factor, factorvec
+    import Primes: isprime, primes, primesmask, factor

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
 julia 0.4
-DataStructures

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+DataStructures

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,8 @@
 using Primes
 using Base.Test
+using DataStructures: SortedDict
 
-import Primes: isprime, primes, primesmask, factor, factorvec
+import Primes: isprime, primes, primesmask, factor
 
 # primes
 
@@ -204,8 +205,13 @@ euler7(n) = primes(floor(Int,n*log(n*log(n))))[n]
 # project euler 10: 142913828922
 @test sum(map(Int64,primes(2000000))) == 142913828922
 
-# factorvec
-@test_throws ArgumentError factorvec(0)
-@test factorvec(1) == Int[]
-@test factorvec(3) == [3]
-@test factorvec(4) == [2,2]
+# factor(Vector, n)
+for V in (Vector, Vector{Int}, Vector{Int128})
+    @test_throws ArgumentError factor(V, 0)
+    @test factor(V, 1) == Int[]
+    @test factor(V, 3) == [3]
+    @test factor(V, 4) == [2,2]
+end
+
+# factor with non-default associative containers
+@test factor(SortedDict, 100) == factor(Dict, 100)


### PR DESCRIPTION
This is an alternative API to #13, and a complement to #14. The user can choose to have `factor` output a `Dict`, a `SortedDict` or a `Vector` via an argument: `factor(12, Dict)`, `factor(12, SortedDict)`, `factor(12, Vector)` (calls `factorvec`, which would then be not exported). The default of `factor(12)` is `Dict` for now, but this will obviously be discussed! (if the idea gets support).
