### PR TITLE
Add a Set method for factor, plus a specific error fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Dict{Int64,Int64} with 2 entries:
     factor(ContainerType, n) -> ContainerType
 
 > Return the factorization of `n` stored in a `ContainerType`, which must be a
-subtype of `Associative`, `AbstractArray`, or `Base.AbstractSet`.
+subtype of `Associative` or `AbstractArray`, a `Set`, or an `IntSet`.
 
 > ```julia
 julia> factor(DataStructures.SortedDict, 100)
@@ -47,16 +47,18 @@ julia> factor(Vector, 100)
  2
  5
  5
+
+julia> prod(factor(Vector, 100)) == 100
+true
 > ```
 
-> When `ContainerType <: Base.AbstractSet`, this returns the distinct prime
+> When `ContainerType == Set`, this returns the distinct prime
 factors as a set.
 
 > ```julia
 julia> factor(Set, 100)
 Set([2,5])
 > ```
-
 
     isprime(x::Integer) -> Bool
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Dict{Int64,Int64} with 2 entries:
 
     factor(ContainerType, n) -> ContainerType
 
-> Return the factorization of `n` using ContainerType
-(a subtype of `Associative` or `AbstractArray`).
+> Return the factorization of `n` stored in a `ContainerType`, which must be a
+subtype of `Associative`, `AbstractArray`, or `Base.AbstractSet`.
 
 > ```julia
 julia> factor(DataStructures.SortedDict, 100)
@@ -48,6 +48,15 @@ julia> factor(Vector, 100)
  5
  5
 > ```
+
+> When `ContainerType <: Base.AbstractSet`, this returns the distinct prime
+factors as a set.
+
+> ```julia
+julia> factor(Set, 100)
+Set([2,5])
+> ```
+
 
     isprime(x::Integer) -> Bool
 

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -256,8 +256,8 @@ end
 """
     factor(ContainerType, n) -> ContainerType
 
-Return the factorization of `n` using ContainerType
-(a subtype of `Associative` or `AbstractArray`).
+Return the factorization of `n` stored in a `ContainerType`, which must be a
+subtype of `Associative`, `AbstractArray`, or `Base.AbstractSet`.
 
 ```jldoctest
 julia> factor(DataStructures.SortedDict, 100)
@@ -280,11 +280,21 @@ julia> factor(Vector, 100)
 julia> prod(factor(Vector, 100)) == 100
 true
 ```
+
+When `ContainerType <: Base.AbstractSet`, this returns the distinct prime
+factors as a set.
+
+```jldoctest
+julia> factor(Set, 100)
+Set([2,5])
+```
 """
 factor{T<:Integer, D<:Associative}(::Type{D}, n::T) = factor(n, D(Dict{T,Int}()))
 factor{T<:Integer, A<:AbstractArray}(::Type{A}, n::T) = A(factor(Vector{T}, n))
 factor{T<:Integer}(::Type{Vector{T}}, n::T) =
     sort!(mapreduce(collect, vcat, Vector{T}(), [repeated(k,v) for (k,v) in factor(n)]))
+factor{T<:Integer, S<:Base.AbstractSet}(::Type{S}, n::T) = S(keys(factor(n)))
+factor{T<:Any}(::Type{T}, n) = throw(MethodError(factor, (T, n)))
 
 
 function pollardfactors!{T<:Integer,K<:Integer}(n::T, h::Associative{K,Int})

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -257,7 +257,7 @@ end
     factor(ContainerType, n) -> ContainerType
 
 Return the factorization of `n` stored in a `ContainerType`, which must be a
-subtype of `Associative`, `AbstractArray`, or `Base.AbstractSet`.
+subtype of `Associative` or `AbstractArray`, a `Set`, or an `IntSet`.
 
 ```jldoctest
 julia> factor(DataStructures.SortedDict, 100)
@@ -281,7 +281,7 @@ julia> prod(factor(Vector, 100)) == 100
 true
 ```
 
-When `ContainerType <: Base.AbstractSet`, this returns the distinct prime
+When `ContainerType == Set`, this returns the distinct prime
 factors as a set.
 
 ```jldoctest
@@ -293,7 +293,7 @@ factor{T<:Integer, D<:Associative}(::Type{D}, n::T) = factor(n, D(Dict{T,Int}())
 factor{T<:Integer, A<:AbstractArray}(::Type{A}, n::T) = A(factor(Vector{T}, n))
 factor{T<:Integer}(::Type{Vector{T}}, n::T) =
     sort!(mapreduce(collect, vcat, Vector{T}(), [repeated(k,v) for (k,v) in factor(n)]))
-factor{T<:Integer, S<:Base.AbstractSet}(::Type{S}, n::T) = S(keys(factor(n)))
+factor{T<:Integer, S<:Union{Set,IntSet}}(::Type{S}, n::T) = S(keys(factor(n)))
 factor{T<:Any}(::Type{T}, n) = throw(MethodError(factor, (T, n)))
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -218,7 +218,7 @@ end
 
 # factor sets
 @test factor(Set, 100) == Set([2, 5])
-@test factor(IntSet, 100) = IntSet([2, 5])
+@test factor(IntSet, 100) == IntSet([2, 5])
 
 # factor other things and fail
 @test_throws MethodError factor(Int, 10)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -215,3 +215,12 @@ end
 
 # factor with non-default associative containers
 @test factor(SortedDict, 100) == factor(Dict, 100)
+
+# factor sets
+@test factor(Set, 100) == Set([2, 5])
+@test factor(IntSet, 100) = IntSet([2, 5])
+
+# factor other things and fail
+@test_throws MethodError factor(Int, 10)
+@test_throws MethodError factor(Any, 10)
+@test_throws MethodError factor(Tuple, 10)


### PR DESCRIPTION
`factor(Set, n)` makes a set of the distinct prime factors. Calling `factor` with a type argument that's anything other than the ones documented is a specific `MethodError`. Currently it's a weird leftover error from Base that says to use the Primes package.