### PR TITLE
allow factoring non-positive numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,22 @@ Dict{Int64,Int64} with 2 entries:
   5 => 2
 > ```
 
+> For convenience, a negative number `n` is factored as `-1*(-n)` (i.e. `-1` is considered
+to be a factor), and `0` is factored as `0^1`:
+> ```julia
+julia> factor(-9) # == -1*3^2
+Dict{Int64,Int64} with 2 entries:
+  -1 => 1
+   3 => 2
+> ```
+
+> ```julia
+julia> factor(0)
+Dict{Int64,Int64} with 1 entries:
+  0 => 1
+> ```
+> ```
+
     factor(ContainerType, n) -> ContainerType
 
 > Return the factorization of `n` stored in a `ContainerType`, which must be a

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,7 +207,6 @@ euler7(n) = primes(floor(Int,n*log(n*log(n))))[n]
 
 # factor(Vector, n)
 for V in (Vector, Vector{Int}, Vector{Int128})
-    @test_throws ArgumentError factor(V, 0)
     @test factor(V, 1) == Int[]
     @test factor(V, 3) == [3]
     @test factor(V, 4) == [2,2]
@@ -224,3 +223,14 @@ end
 @test_throws MethodError factor(Int, 10)
 @test_throws MethodError factor(Any, 10)
 @test_throws MethodError factor(Tuple, 10)
+
+# factor non-positive numbers:
+@test factor(0) == Dict(0=>1)
+@test factor(-1) == Dict(-1=>1)
+@test factor(-9) == Dict(-1=>1, 3=>2)
+
+@test factor(typemin(Int32)) == Dict(-1=>1, 2=>31)
+@test factor(typemin(Int64)) == Dict(-1=>1, 2=>63)
+@test factor(typemin(Int128)) == Dict(-1=>1, 2=>127)
+
+@test factor(1) == Dict{Int,Int}()


### PR DESCRIPTION
This adds convenience extensions to "pure" factorization of natural numbers. The first change seems to be rather uncontroversial among computer algebra systems (e.g. Magma, SageMath, Pari): a negative number has -1 as a factor:
```
julia> factor(-9)
Dict{Int64,Int64} with 2 entries:
  -1 => 1
   3 => 2
```
The second change concerns zero, wich is factored as `0^1`. This erros on Magma and SageMath, but is defined in Pari, which was built by world-class number theorist (its creator has been my teacher in master :-p), so it would be credible to do the same. 
```
julia> factor(0)
Dict{Int64,Int64} with 0 entries:
  0 => 1
```
