### PR TITLE
ismersenneprime: fix incorrect check test

### DIFF
--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -429,6 +429,7 @@ function ismersenneprime(M::Integer; check::Bool = true)
         M >= 0 && isprime(length(b)) && !('0' in b) ||
             throw(ArgumentError("The argument given is not a valid Mersenne Number (`M = 2^p - 1`)."))
     end
+    M < 7 && return M == 3
     return ll_primecheck(M)
 end
 

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -425,8 +425,8 @@ true
 """
 function ismersenneprime(M::Integer; check::Bool = true)
     if check
-        b = bin(M)
-        M >= 0 && isprime(length(b)) && !('0' in b) ||
+        d = ndigits(M, 2)
+        M >= 0 && isprime(d) && (M >> d == 0) ||
             throw(ArgumentError("The argument given is not a valid Mersenne Number (`M = 2^p - 1`)."))
     end
     M < 7 && return M == 3

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -408,10 +408,12 @@ end
 """
     ismersenneprime(M::Integer; [check::Bool = true]) -> Bool
 
-Lucas-Lehmer deterministic test for primes of the form
-`M = 2^p - 1`, also known as Mersenne primes. Use keyword argument `check`
-to enable/disable check for `M` is a valid Mersenne number; to be used with caution.
-Returns `true` if given Mersenne number is prime, and `false` otherwise.
+Lucas-Lehmer deterministic test for Mersenne primes. `M` must be a
+Mersenne number, i.e. of the form `M = 2^p - 1`, where `p` is a prime
+number. Use the keyword argument `check` to enable/disable checking
+whether `M` is a valid Mersenne number; to be used with caution.
+Return `true` if the given Mersenne number is prime, and `false`
+otherwise.
 
 ```jldoctest
 julia> ismersenneprime(2^11 - 1)
@@ -422,7 +424,11 @@ true
 ```
 """
 function ismersenneprime(M::Integer; check::Bool = true)
-    (check && isprime(length(bin(M)))) || throw(ArgumentError("The argument given is not a valid Mersenne Number (`M = 2^p - 1`)."))
+    if check
+        b = bin(M)
+        M >= 0 && isprime(length(b)) && !('0' in b) ||
+            throw(ArgumentError("The argument given is not a valid Mersenne Number (`M = 2^p - 1`)."))
+    end
     return ll_primecheck(M)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -240,6 +240,10 @@ end
 @test !ismersenneprime(2047)
 @test ismersenneprime(8191)
 @test_throws ArgumentError ismersenneprime(3)
+@test_throws ArgumentError ismersenneprime(9)
+@test_throws ArgumentError ismersenneprime(9, check=true)
+# test the following does not throw
+ismersenneprime(9, check=false)
 
 #  Lucas-Lehmer-Riesel
 @test_throws ArgumentError isrieselprime(1000, 511)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -239,7 +239,6 @@ end
 # Lucas-Lehmer
 @test !ismersenneprime(2047)
 @test ismersenneprime(8191)
-@test_throws ArgumentError ismersenneprime(3)
 @test_throws ArgumentError ismersenneprime(9)
 @test_throws ArgumentError ismersenneprime(9, check=true)
 # test the following does not throw


### PR DESCRIPTION
The boolean operators (for `check`) where not in the correct order, the precondition that `M` is a Mersenne number was not fully enforced even for `check=true` (need to check that `0` is not in the binary representation of `M`), it was not documented that `p` must be a prime,  and an error was thrown when `M < 7`, which was not documented and not useful. cc @vinctux 