### PR TITLE
Replace isprime

### DIFF
--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -267,6 +267,7 @@ function factor!{T<:Integer,K<:Integer}(n::T, h::Associative{K,Int})
             p^2 >= n && (h[n] = 1; return h)
         end
     end
+    isprime(n) && (h[n] = 1; return h)
     T <: BigInt || widemul(n - 1, n - 1) ≤ typemax(n) ? pollardfactors!(n, h) : pollardfactors!(widen(n), h)
 end
 

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -264,7 +264,7 @@ function factor!{T<:Integer,K<:Integer}(n::T, h::Associative{K,Int})
                 n = div(n, p)
             end
             n == 1 && return h
-            isprime(n) && (h[n] = 1; return h)
+            p^2 >= n && (h[n] = 1; return h)
         end
     end
     T <: BigInt || widemul(n - 1, n - 1) ≤ typemax(n) ? pollardfactors!(n, h) : pollardfactors!(widen(n), h)


### PR DESCRIPTION
Replace isprime with weaker, but orders of magnitude faster test. Better to finish testing primes up to 2^16, then performing Miller-Rabin as many times as different prime factors.

Related issue: https://github.com/JuliaMath/Primes.jl/issues/49