### PR TITLE
WIP: pollardfactors! : when two divisors are found, exploit their gcd

### DIFF
--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -463,7 +463,7 @@ end
 # given two found non-trivial factors a and b=n/a of n, apply
 # recursively the algorithm (via `continuation!`) for the non-prime
 # factors, otherwise update the factors list `h`
-function recurse_with_subfactors!{T<:Integer}(a::T, b::T, h::Associative{T,Int}, multiplicity, continuation!)
+function recurse_with_subfactors!{T<:Integer}(a::T, b::T, h::Associative, multiplicity, continuation!)
     facts = Factorization{T}()
     pairwise_coprime!(a, multiplicity, b, multiplicity, facts)
     for (f, mult) in facts

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -468,7 +468,7 @@ function recurse_with_subfactors!{T<:Integer}(a::T, b::T, h::Associative{T,Int},
     pairwise_coprime!(a, multiplicity, b, multiplicity, facts)
     pr = Set(f[1] for f in facts if isprime(f[1]))
     for (f, mult) in facts
-        f == 1 && continue
+        f != 1 && mult != 0 || continue
         if f in pr # f is prime
             h[f] = get(h, f, 0) + mult
         else

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -444,7 +444,7 @@ end
 # populate facts with pairwise-coprimes divisors of a and b (with
 # appropriate multiplicity) using repeated gcd applications, such
 # that prod(facts) == a^ma*b^mb
-function pairwise_coprime!(a::T, ma, b::T, mb, facts) where T
+function pairwise_coprime!{T}(a::T, ma::Int, b::T, mb::Int, facts::Factorization)
     a == b && (facts[a] += ma+mb;
                return b)
     d = gcd(a, b)

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -466,20 +466,11 @@ end
 function recurse_with_subfactors!{T<:Integer}(a::T, b::T, h::Associative{T,Int}, multiplicity, continuation!)
     facts = Factorization{T}()
     pairwise_coprime!(a, multiplicity, b, multiplicity, facts)
-    pr = Set(f[1] for f in facts if isprime(f[1]))
     for (f, mult) in facts
         f != 1 && mult != 0 || continue
-        if f in pr # f is prime
-            h[f] = get(h, f, 0) + mult
-        else
-            for p in pr # check if any of the known primes would divide f
-                while f % p == 0
-                    h[p] = get(h, p, 0) + mult
-                    f ÷= p
-                end
-            end
-            f != 1 && continuation!(f, h, mult)
-        end
+        isprime(f) ?
+            h[f] = get(h, f, 0) + mult :
+            continuation!(f, h, mult)
     end
 end
 

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -8,11 +8,13 @@ immutable Factorization{T<:Integer} <: Associative{T, Int}
     (::Type{Factorization{T}}){T<:Integer}() = new{T}(Vector{Pair{T, Int}}())
 end
 
-function (::Type{Factorization{T}}){T<:Integer}(d::Associative)
+function (::Type{Factorization{T}}){T<:Integer}(d::Union{Associative,Tuple{Vararg{Pair{T,Int}}}})
     f = Factorization{T}()
     append!(f.pe, sort!(collect(d)))
     f
 end
+
+(::Type{Factorization}){T<:Integer}(pe::Pair{T,Int}...) = Factorization{T}(pe)
 
 Base.convert{T}(::Type{Factorization}, d::Associative{T}) = Factorization{T}(d)
 

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -42,6 +42,8 @@ function Base.setindex!{T}(f::Factorization{T}, e::Int, p::Integer)
     f
 end
 
+Base.pop!(f::Factorization) = pop!(f.pe)
+
 Base.length(f::Factorization) = length(f.pe)
 
 Base.show(io::IO, ::MIME{Symbol("text/plain")}, f::Factorization) =


### PR DESCRIPTION
When a factor `G` of `n` was found with `pollardfactors!`, the algo was called recursively on `G` and `G2=div(n,G)`. Here, we check whether `G` and `G2` have common divisors, which can happen easily when `n` has prime factors with big multiplicities. For example, the following is about 10 times faster with this PR:
```
 srand(0); @time factor(prod(nextprime(big(Primes.PRIMES[end]), i) for i in 10:29)^20)
```
The first commit is a first step, the 2nd one makes derecursives the function (which will be useful when optimizing it for `BigInt` (I have a PR almost ready for that), the 3rd one completes the work of finding all possible divisors of `G` and `G2` via `gcd` (WIP as I need to check again that the algo is correct), the remaining commits are small fixes. 