### PR TITLE
add nextprimes/prevprimes iterators (fix #55)

### DIFF
--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -671,7 +671,7 @@ prime(::Type{T}, i::Integer) where {T<:Integer} = i < 0 ? throw(DomainError(i)) 
 prime(i::Integer) = prime(Int, i)
 
 
-struct NextPrimes{T<:Integer}
+immutable NextPrimes{T<:Integer}
     start::T
 end
 
@@ -719,7 +719,7 @@ julia> nextprimes(10, 3)
 nextprimes{T<:Integer}(start::T, n::Integer) =
     iterate(x->nextprime(add(x, 1)), nextprime(start), n)
 
-struct PrevPrimes{T<:Integer}
+immutable PrevPrimes{T<:Integer}
     start::T
 end
 

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -732,7 +732,7 @@ iterate(np::PrevPrimes, state=np.start) =
     end
 
 IteratorSize(::Type{<:PrevPrimes}) = Base.SizeUnknown()
-Iteratoreltype(::Type{<:PrevPrimes}) = Base.HasEltype()
+IteratorEltype(::Type{<:PrevPrimes}) = Base.HasEltype()
 
 eltype(::Type{PrevPrimes{T}}) where {T} = T
 

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -682,7 +682,7 @@ Base.done(np::NextPrimes, state) = false
 Base.iteratorsize(::Type{<:NextPrimes}) = Base.IsInfinite()
 Base.iteratoreltype(::Type{<:NextPrimes}) = Base.HasEltype() # default
 
-Base.eltype{T}(::Type{NextPrimes{T}}) = T
+Base.eltype(::Type{NextPrimes{T}}) where {T} = T
 
 """
     nextprimes(start::Integer)
@@ -698,7 +698,7 @@ nextprimes(start::Integer) = NextPrimes(start)
 Returns an iterator over all primes, with type `T`.
 Equivalent to `nextprimes(T(1))`.
 """
-nextprimes{T<:Integer}(::Type{T}) = nextprimes(one(T))
+nextprimes(::Type{T}) where {T<:Integer} = nextprimes(one(T))
 nextprimes() = nextprimes(Int)
 
 """
@@ -716,7 +716,7 @@ julia> nextprimes(10, 3)
  17
 ```
 """
-nextprimes{T<:Integer}(start::T, n::Integer) = collect(T, take(nextprimes(start), n))
+nextprimes(start::T, n::Integer) where {T<:Integer} = collect(T, take(nextprimes(start), n))
 
 struct PrevPrimes{T<:Integer}
     start::T
@@ -729,7 +729,7 @@ done(np::PrevPrimes, state) = state == 2
 iteratorsize(::Type{<:PrevPrimes}) = Base.SizeUnknown()
 iteratoreltype(::Type{<:PrevPrimes}) = Base.HasEltype() # default
 
-eltype{T}(::Type{PrevPrimes{T}}) = T
+eltype(::Type{PrevPrimes{T}}) where {T} = T
 
 """
     prevprimes(start::Integer)
@@ -766,6 +766,6 @@ julia> prevprimes(10, 3)
  3
 ```
 """
-prevprimes{T<:Integer}(start::T, n::Integer) = collect(T, take(prevprimes(start, n)))
+prevprimes(start::T, n::Integer) where {T<:Integer} = collect(T, take(prevprimes(start, n)))
 
 end # module

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -716,8 +716,7 @@ julia> nextprimes(10, 3)
  17
 ```
 """
-nextprimes{T<:Integer}(start::T, n::Integer) =
-    iterate(x->nextprime(add(x, 1)), nextprime(start), n)
+nextprimes{T<:Integer}(start::T, n::Integer) = collect(T, take(nextprimes(start), n))
 
 immutable PrevPrimes{T<:Integer}
     start::T
@@ -767,17 +766,6 @@ julia> prevprimes(10, 3)
  3
 ```
 """
-prevprimes{T<:Integer}(start::T, n::Integer) =
-    iterate(x->prevprime(add(x, -1)), prevprime(start), n)
-
-function iterate(f, x, n::Integer)
-    v = Vector{eltype(x)}(n)
-    n != 0 && (@inbounds v[1] = x)
-    @inbounds for i = 2:n
-        x = f(x)
-        v[i] = x
-    end
-    v
-end
+prevprimes{T<:Integer}(start::T, n::Integer) = collect(T, take(prevprimes(start, n)))
 
 end # module

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -4,11 +4,12 @@ module Primes
 
 using Base.Iterators: repeated
 
+import Base: start, next, done, eltype, iteratorsize, iteratoreltype
 using Base: BitSigned
 using Base.Checked: checked_neg
 
 export isprime, primes, primesmask, factor, ismersenneprime, isrieselprime,
-       nextprime, prevprime, prime, prodfactors, radical, totient
+       nextprime, nextprimes, prevprime, prevprimes, prime, prodfactors, radical, totient
 
 include("factorization.jl")
 
@@ -528,6 +529,11 @@ function totient(n::Integer)
     totient(factor(abs(n)))
 end
 
+# add: checked add (when makes sense), result of same type as first argument
+
+add(n::BigInt, x::Int) = n+x
+add(n::Integer, x::Int) = Base.checked_add(n, oftype(n, x))
+
 # add_! : "may" mutate the Integer argument (only for BigInt currently)
 
 # modify a BigInt in-place
@@ -541,7 +547,7 @@ function add_!(n::BigInt, x::Int)
 end
 
 # checked addition, without mutation
-add_!(n::Integer, x::Int) = Base.checked_add(n, oftype(n, x))
+add_!(n::Integer, x::Int) = add(n, x)
 
 """
     nextprime(n::Integer, i::Integer=1; interval::Integer=1)
@@ -663,5 +669,115 @@ julia> prime(3)
 """
 prime(::Type{T}, i::Integer) where {T<:Integer} = i < 0 ? throw(DomainError(i)) : nextprime(T(2), i)
 prime(i::Integer) = prime(Int, i)
+
+
+struct NextPrimes{T<:Integer}
+    start::T
+end
+
+Base.start(np::NextPrimes) = np.start < 2 ? np.start : add(np.start, -1)
+Base.next(np::NextPrimes, state) = (p = nextprime(add(state, 1)); (p, p))
+Base.done(np::NextPrimes, state) = false
+
+Base.iteratorsize(::Type{<:NextPrimes}) = Base.IsInfinite()
+Base.iteratoreltype(::Type{<:NextPrimes}) = Base.HasEltype() # default
+
+Base.eltype(::Type{NextPrimes{T}}) where {T} = T
+
+"""
+    nextprimes(start::Integer)
+
+Returns an iterator over all primes greater than or equal to `start`,
+in ascending order.
+"""
+nextprimes(start::Integer) = NextPrimes(start)
+
+"""
+    nextprimes(T::Type=Int)
+
+Returns an iterator over all primes, with type `T`.
+Equivalent to `nextprimes(T(1))`.
+"""
+nextprimes(::Type{T}) where {T<:Integer} = nextprimes(one(T))
+nextprimes() = nextprimes(Int)
+
+"""
+    nextprimes(start::Integer, n::Integer)
+
+Returns an array of the first `n` primes greater than or equal to `start`.
+
+# Example
+
+```
+julia> nextprimes(10, 3)
+3-element Array{Int64,1}:
+ 11
+ 13
+ 17
+```
+"""
+nextprimes(start::T, n::Integer) where {T<:Integer} =
+    iterate(x->nextprime(add(x, 1)), nextprime(start), n)
+
+struct PrevPrimes{T<:Integer}
+    start::T
+end
+
+start(np::PrevPrimes) = np.start+one(np.start) # allow wrap-around
+next(np::PrevPrimes, state) = (p = prevprime(state-one(state)); (p, p))
+done(np::PrevPrimes, state) = state == 2
+
+iteratorsize(::Type{<:PrevPrimes}) = Base.SizeUnknown()
+iteratoreltype(::Type{<:PrevPrimes}) = Base.HasEltype() # default
+
+eltype(::Type{PrevPrimes{T}}) where {T} = T
+
+"""
+    prevprimes(start::Integer)
+
+Returns an iterator over all primes less than or equal to `start`,
+in descending order.
+
+# Example
+
+```
+julia> collect(prevprimes(10))
+4-element Array{Int64,1}:
+ 7
+ 5
+ 3
+ 2
+```
+"""
+prevprimes(start::Integer) = PrevPrimes(max(one(start), start))
+
+"""
+    prevprimes(start::Integer, n::Integer)
+
+Returns an array of the first `n` primes less than or equal to `start`,
+in descending order.
+
+# Example
+
+```
+julia> prevprimes(10, 3)
+3-element Array{Int64,1}:
+ 7
+ 5
+ 3
+```
+"""
+prevprimes(start::T, n::Integer) where {T<:Integer} =
+    iterate(x->prevprime(add(x, -1)), prevprime(start), n)
+
+function iterate(f, x::T, n::Integer) where T
+    v = Vector{T}(n)
+    n != 0 && (@inbounds v[1] = x)
+    @inbounds for i = 2:n
+        x = f(x)
+        v[i] = x
+    end
+    v
+end
 
 end # module

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -675,11 +675,9 @@ struct NextPrimes{T<:Integer}
     start::T
 end
 
-function iterate(np::NextPrimes,
-                 state = p = np.start < 2 ? np.start : add(np.start, -1)
-                 )
-    p = nextprime(add(state, 1))
-    (p, p)
+function iterate(np::NextPrimes, state=np.start)
+    p = nextprime(state)
+    (p, add(p, 1))
 end
 
 IteratorSize(::Type{<:NextPrimes}) = Base.IsInfinite()
@@ -725,17 +723,13 @@ struct PrevPrimes{T<:Integer}
     start::T
 end
 
-function iterate(np::PrevPrimes,
-                 state = np.start+one(np.start) # allow wrap-around
-                 )
-    c = state-one(state)
-    if isone(c)
+iterate(np::PrevPrimes, state=np.start) =
+    if isone(state)
         nothing
     else
-        p = prevprime(c)
-        (p, p)
+        p = prevprime(state)
+        (p, p-one(p))
     end
-end
 
 IteratorSize(::Type{<:PrevPrimes}) = Base.SizeUnknown()
 Iteratoreltype(::Type{<:PrevPrimes}) = Base.HasEltype()

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -671,7 +671,7 @@ prime(::Type{T}, i::Integer) where {T<:Integer} = i < 0 ? throw(DomainError(i)) 
 prime(i::Integer) = prime(Int, i)
 
 
-immutable NextPrimes{T<:Integer}
+struct NextPrimes{T<:Integer}
     start::T
 end
 
@@ -718,7 +718,7 @@ julia> nextprimes(10, 3)
 """
 nextprimes{T<:Integer}(start::T, n::Integer) = collect(T, take(nextprimes(start), n))
 
-immutable PrevPrimes{T<:Integer}
+struct PrevPrimes{T<:Integer}
     start::T
 end
 

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -682,7 +682,7 @@ Base.done(np::NextPrimes, state) = false
 Base.iteratorsize(::Type{<:NextPrimes}) = Base.IsInfinite()
 Base.iteratoreltype(::Type{<:NextPrimes}) = Base.HasEltype() # default
 
-Base.eltype(::Type{NextPrimes{T}}) where {T} = T
+Base.eltype{T}(::Type{NextPrimes{T}}) = T
 
 """
     nextprimes(start::Integer)
@@ -698,7 +698,7 @@ nextprimes(start::Integer) = NextPrimes(start)
 Returns an iterator over all primes, with type `T`.
 Equivalent to `nextprimes(T(1))`.
 """
-nextprimes(::Type{T}) where {T<:Integer} = nextprimes(one(T))
+nextprimes{T<:Integer}(::Type{T}) = nextprimes(one(T))
 nextprimes() = nextprimes(Int)
 
 """
@@ -716,7 +716,7 @@ julia> nextprimes(10, 3)
  17
 ```
 """
-nextprimes(start::T, n::Integer) where {T<:Integer} =
+nextprimes{T<:Integer}(start::T, n::Integer) =
     iterate(x->nextprime(add(x, 1)), nextprime(start), n)
 
 struct PrevPrimes{T<:Integer}
@@ -730,7 +730,7 @@ done(np::PrevPrimes, state) = state == 2
 iteratorsize(::Type{<:PrevPrimes}) = Base.SizeUnknown()
 iteratoreltype(::Type{<:PrevPrimes}) = Base.HasEltype() # default
 
-eltype(::Type{PrevPrimes{T}}) where {T} = T
+eltype{T}(::Type{PrevPrimes{T}}) = T
 
 """
     prevprimes(start::Integer)
@@ -767,11 +767,11 @@ julia> prevprimes(10, 3)
  3
 ```
 """
-prevprimes(start::T, n::Integer) where {T<:Integer} =
+prevprimes{T<:Integer}(start::T, n::Integer) =
     iterate(x->prevprime(add(x, -1)), prevprime(start), n)
 
-function iterate(f, x::T, n::Integer) where T
-    v = Vector{T}(n)
+function iterate(f, x, n::Integer)
+    v = Vector{eltype(x)}(n)
     n != 0 && (@inbounds v[1] = x)
     @inbounds for i = 2:n
         x = f(x)

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -531,7 +531,7 @@ end
 
 # add: checked add (when makes sense), result of same type as first argument
 
-add(n::BigInt, x::Int) = n+x
+add(n::BigInt, x::Int) = n + x
 add(n::Integer, x::Int) = Base.checked_add(n, oftype(n, x))
 
 # add_! : "may" mutate the Integer argument (only for BigInt currently)
@@ -723,13 +723,14 @@ struct PrevPrimes{T<:Integer}
     start::T
 end
 
-iterate(np::PrevPrimes, state=np.start) =
+function iterate(np::PrevPrimes, state=np.start)
     if isone(state)
         nothing
     else
         p = prevprime(state)
         (p, p-one(p))
     end
+end
 
 IteratorSize(::Type{<:PrevPrimes}) = Base.SizeUnknown()
 IteratorEltype(::Type{<:PrevPrimes}) = Base.HasEltype()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -390,3 +390,38 @@ for T in (Int, UInt, BigInt)
     @test prodfactors(factor(Set, T(123456))) == 3858
     @test prod(factor(T(123456))) == 123456
 end
+
+@testset "nextprimes(::$T)" for T = (Int32, Int64, BigInt)
+    for (i, p) in enumerate(nextprimes(T))
+        @test nextprime(0, i) == p
+        i > 20 && break
+    end
+    @test nextprimes() == nextprimes(Int)
+    for (i, p) in enumerate(nextprimes(T(5)))
+        @test nextprime(T(5), i) == p
+        i > 20 && break
+    end
+    @test nextprimes(T(5), 10) == [nextprime(T(5), i) for i=1:10]
+    @test nextprimes(1, 1)[1] == nextprimes(2, 1)[1] == 2
+    @test nextprimes(3, 1)[1] == 3
+    @test nextprimes(4, 1)[1] == nextprimes(5, 1)[1] == 5
+end
+
+
+@testset "prevprimes(::$T)" for T = (Int32, Int64, BigInt)
+    for (i, p) in enumerate(prevprimes(T(500)))
+        @test prevprime(T(500), i) == p
+        i > 20 && break
+    end
+    @test prevprimes(T(500), 10) == [prevprime(T(500), i) for i=1:10]
+    @test prevprimes(6, 1)[1] == prevprimes(5, 1)[1] == 5
+    @test prevprimes(4, 1)[1] == prevprimes(3, 1)[1] == 3
+    @test prevprimes(2, 1)[1] == 2
+    @test_throws ArgumentError prevprimes(2, 2)
+    let p8 = collect(prevprimes(typemax(Int8)))
+        @test length(p8) == 31
+        @test p8[end] == 2
+        @test p8[1] == 127
+    end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -405,6 +405,8 @@ end
     @test nextprimes(1, 1)[1] == nextprimes(2, 1)[1] == 2
     @test nextprimes(3, 1)[1] == 3
     @test nextprimes(4, 1)[1] == nextprimes(5, 1)[1] == 5
+    @test eltype(nextprimes(10)) == Int
+    @test eltype(nextprimes(big(10))) == BigInt
 end
 
 
@@ -421,6 +423,8 @@ end
         @test length(p8) == 31
         @test p8[end] == 2
         @test p8[1] == 127
+        @test eltype(p8) == Int8
     end
-
+    @test eltype(prevprimes(10)) == Int
+    @test eltype(prevprimes(big(10))) == BigInt
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -417,7 +417,6 @@ end
     @test prevprimes(6, 1)[1] == prevprimes(5, 1)[1] == 5
     @test prevprimes(4, 1)[1] == prevprimes(3, 1)[1] == 3
     @test prevprimes(2, 1)[1] == 2
-    @test_throws ArgumentError prevprimes(2, 2)
     let p8 = collect(prevprimes(typemax(Int8)))
         @test length(p8) == 31
         @test p8[end] == 2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -407,6 +407,9 @@ end
     @test nextprimes(4, 1)[1] == nextprimes(5, 1)[1] == 5
     @test eltype(nextprimes(10)) == Int
     @test eltype(nextprimes(big(10))) == BigInt
+    @test Base.IteratorEltype(nextprimes(10)) == Base.HasEltype()
+    @test Base.IteratorSize(nextprimes(10)) == Base.IsInfinite()
+
 end
 
 
@@ -419,6 +422,7 @@ end
     @test prevprimes(6, 1)[1] == prevprimes(5, 1)[1] == 5
     @test prevprimes(4, 1)[1] == prevprimes(3, 1)[1] == 3
     @test prevprimes(2, 1)[1] == 2
+    @test isempty(prevprimes(1, 1))
     let p8 = collect(prevprimes(typemax(Int8)))
         @test length(p8) == 31
         @test p8[end] == 2
@@ -427,4 +431,6 @@ end
     end
     @test eltype(prevprimes(10)) == Int
     @test eltype(prevprimes(big(10))) == BigInt
+    @test Base.IteratorEltype(prevprimes(10)) == Base.HasEltype()
+    @test Base.IteratorSize(prevprimes(10)) == Base.SizeUnknown()
 end


### PR DESCRIPTION
This adds a `nextprimes(n)` iterator to iterate over all primes greater than `n`. This comes also with an "array" version `nextprimes(n, k)` containing `k` elements (I saw myself too often using the horribly inefficient `[nextprime(n, i) for i in 1:k]` ;-p)
Similarly for `prevprimes`.
Of course, the names can be bikeshed :)