### PR TITLE
Primes.totient was not showing up in the documentation

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -9,7 +9,6 @@ DocTestSetup = :(using Primes)
 ```@docs
 Primes.factor
 Primes.prodfactors
-Primes.radical
 ```
 
 ## Generating prime numbers
@@ -27,4 +26,11 @@ Primes.prime
 Primes.isprime
 Primes.ismersenneprime
 Primes.primesmask
+```
+
+## Multiplicative functions
+
+```@docs
+Primes.radical
+Primes.totient
 ```

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -28,7 +28,7 @@ Primes.ismersenneprime
 Primes.primesmask
 ```
 
-## Multiplicative functions
+## Number-theoretic functions
 
 ```@docs
 Primes.radical


### PR DESCRIPTION
Thus I edited `api.md` to include `totient`. Also, I created a new subsection `Number-theoretic functions` (see  https://en.wikipedia.org/wiki/Arithmetic_function for terminology), where I put `totient` and `radical` under. I plan to add a whole bunch of such functions (which are easily computed from the prime decomposition of the given integer).