### PR TITLE
allow `primes(..., typemax(Int))` without throwing an error

### DIFF
--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -63,9 +63,11 @@ function _primesmask(lo::Int, hi::Int)
         if small_sieve[i]
             p = wheel_prime(i)
             j = wheel_index(2 * div(lo - p - 1, 2p) + 1)
-            q = p * wheel_prime(j + 1)
+            r = widemul(p, wheel_prime(j + 1))
+            r > m && continue
             j = j & 7 + 1
-            while q ≤ m
+            q = Int(r)
+            while 0 ≤ q ≤ m
                 sieve[wheel_index(q) - wlo] = false
                 q += wheel[j] * p
                 j = j & 7 + 1

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -64,9 +64,10 @@ function _primesmask(lo::Int, hi::Int)
             p = wheel_prime(i)
             j = wheel_index(2 * div(lo - p - 1, 2p) + 1)
             r = widemul(p, wheel_prime(j + 1))
-            r > m && continue
+            r > m && continue # use widemul to avoid r <= m caused by overflow
             j = j & 7 + 1
             q = Int(r)
+            # q < 0 indicates overflow when incrementing q inside loop
             while 0 ≤ q ≤ m
                 sieve[wheel_index(q) - wlo] = false
                 q += wheel[j] * p

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -451,3 +451,7 @@ end
     @test Base.IteratorEltype(prevprimes(10)) == Base.HasEltype()
     @test Base.IteratorSize(prevprimes(10)) == Base.SizeUnknown()
 end
+
+@testset "primes with huge arguments" begin
+    @test primes(2^63-200, 2^63-1) == [9223372036854775643, 9223372036854775783]
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -453,5 +453,8 @@ end
 end
 
 @testset "primes with huge arguments" begin
-    @test primes(2^63-200, 2^63-1) == [9223372036854775643, 9223372036854775783]
+    if Base.Sys.WORD_SIZE == 64
+        @test primes(2^63-200, 2^63-1) == [9223372036854775643, 9223372036854775783]
+    end
+    @test primes(2^31-20, 2^31-1) == [2147483629, 2147483647]
 end


### PR DESCRIPTION
Fixes #76.