### PR TITLE
CI: test on julia 1.2, 1.3, and allow nightly failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ julia:
   - 1.1
   - 1.2
   - 1.3
+  - 1.4
   - nightly
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,12 @@ julia:
   - 0.7
   - 1.0
   - 1.1
+  - 1.2
+  - 1.3
   - nightly
+matrix:
+  allow_failures:
+  - julia: nightly
 notifications:
   email: false
 # uncomment the following lines to override the default test script

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
   - julia_version: 1.1
   - julia_version: 1.2
   - julia_version: 1.3
+  - julia_version: 1.4
   - julia_version: nightly
 matrix:
   allow_failures:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,12 @@ environment:
   - julia_version: 0.7
   - julia_version: 1.0
   - julia_version: 1.1
+  - julia_version: 1.2
+  - julia_version: 1.3
   - julia_version: nightly
+matrix:
+  allow_failures:
+    - julia_version: nightly
 platform:
   - x86 # 32-bit
   - x64 # 64-bit


### PR DESCRIPTION
I'm not sure if the failure in #78 is my responsibility, if it isn't I suggest allowing nightly to fail in CI. In any case, we should now test 1.3 and probably 1.2.