### PR TITLE
WIP: upgrade factor!, and maybe remove factor(ContainerType, n)

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -8,6 +8,7 @@ DocTestSetup = :(using Primes)
 
 ```@docs
 Primes.factor
+Primes.factor!
 Primes.prodfactors
 ```
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -239,6 +239,12 @@ end
 # factor returns a sorted dict
 @test all([issorted(collect(factor(rand(Int)))) for x in 1:100])
 
+@testset "factor!" begin
+    @test factor!(Int[], -50) == [-1, 2, 5, 5]
+    @test factor!(Set{Int}(), -50) == Set([-1, 2, 5])
+    @test factor!(Dict{Int,Int}(), -50) == Dict(-1 => 1, 2 => 1, 5 => 2)
+end
+
 # Lucas-Lehmer
 @test !ismersenneprime(2047)
 @test ismersenneprime(8191)


### PR DESCRIPTION
Cf. discussion at https://github.com/JuliaMath/Primes.jl/pull/78#discussion_r352474088.
This allows for example `factor(Int[], 123)`. 
Should we remove `factor(Vector, 123)`, deprecated it? 
Or should we just remove the generic methods (`factor(::Type{AbstractArray})`, `factor(::Type{AbstractDict})`, etc.) and keep the ones with `Base` types (which we know how to instantiate)?
I would just remove them all before we tag 1.0.