### PR TITLE
update Primes.jl

### DIFF
--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -112,6 +112,9 @@ primesmask(n::Integer) = n ≤ typemax(Int) ? primesmask(Int(n)) :
 Returns a collection of the prime numbers (from `lo`, if specified) up to `hi`.
 """
 function primes(lo::Int, hi::Int)
+    if hi<1
+    list=Int[]
+    else
     lo ≤ hi || throw(ArgumentError("The condition lo ≤ hi must be met."))
     list = Int[]
     lo ≤ 2 ≤ hi && push!(list, 2)
@@ -124,6 +127,7 @@ function primes(lo::Int, hi::Int)
     lwi = wheel_index(lo - 1)
     @inbounds for i = 1:length(sieve)   # don't use eachindex here
         sieve[i] && push!(list, wheel_prime(i + lwi))
+    end
     end
     return list
 end

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -127,7 +127,7 @@ function primes(lo::Int, hi::Int)
     end
     return list
 end
-primes(n::Int) = primes(1, n)
+primes(n::Int) = primes(0, n)
 
 const PRIMES = primes(2^16)
 


### PR DESCRIPTION
Earlier primes(0) will through error like "The condition lo ≤ hi must be met." but now
primes(0) will return output as look like primes(0,0).