### PR TITLE
Remove `isprime` from trial division part of `factor`

### DIFF
--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -265,9 +265,14 @@ function factor!(n::T, h::AbstractDict{K,Int}) where {T<:Integer,K<:Integer}
                 n = div(n, p)
             end
             n == 1 && return h
-            isprime(n) && (h[n] = 1; return h)
+            if T==BigInt 
+                isprime(n, reps=1) && (h[n] = 1; return h)
+            else
+                isprime(n) && (h[n] = 1; return h)
+            end
         end
     end
+    isprime(n) && h[n]=1; return h
     T <: BigInt || widemul(n - 1, n - 1) ≤ typemax(n) ? pollardfactors!(n, h) : pollardfactors!(widen(n), h)
 end
 

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -272,7 +272,7 @@ function factor!(n::T, h::AbstractDict{K,Int}) where {T<:Integer,K<:Integer}
             end
         end
     end
-    isprime(n) && (h[n]=1; return h)
+    T==BigInt && isprime(n) && (h[n]=1; return h)
     T <: BigInt || widemul(n - 1, n - 1) ≤ typemax(n) ? pollardfactors!(n, h) : pollardfactors!(widen(n), h)
 end
 

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -266,7 +266,7 @@ function factor!(n::T, h::AbstractDict{K,Int}) where {T<:Integer,K<:Integer}
             end
             n == 1 && return h
             if T==BigInt 
-                isprime(n, reps=1) && (h[n] = 1; return h)
+                isprime(n, 1) && (h[n] = 1; return h)
             else
                 isprime(n) && (h[n] = 1; return h)
             end

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -256,7 +256,9 @@ function factor!(n::T, h::AbstractDict{K,Int}) where {T<:Integer,K<:Integer}
     end
 
     local p::T
+    nsqrt = isqrt(n)
     for p in PRIMES
+        p > nsqrt && break
         if n % p == 0
             h[p] = get(h, p, 0) + 1
             n = div(n, p)

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -267,6 +267,7 @@ function factor!(n::T, h::AbstractDict{K,Int}) where {T<:Integer,K<:Integer}
                 n = div(n, p)
             end
             n == 1 && return h
+            nsqrt = isqrt(n)
         end
     end
     isprime(n) && (h[n]=1; return h)

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -266,7 +266,7 @@ function factor!(n::T, h::AbstractDict{K,Int}) where {T<:Integer,K<:Integer}
             end
             n == 1 && return h
             if T==BigInt 
-                isprime(n, 1) && (h[n] = 1; return h)
+                isprime(n, 4) && (h[n] = 1; return h)
             else
                 isprime(n) && (h[n] = 1; return h)
             end

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -265,14 +265,9 @@ function factor!(n::T, h::AbstractDict{K,Int}) where {T<:Integer,K<:Integer}
                 n = div(n, p)
             end
             n == 1 && return h
-            if T==BigInt 
-                isprime(n, 4) && (h[n] = 1; return h)
-            else
-                isprime(n) && (h[n] = 1; return h)
-            end
         end
     end
-    T==BigInt && isprime(n) && (h[n]=1; return h)
+    isprime(n) && (h[n]=1; return h)
     T <: BigInt || widemul(n - 1, n - 1) ≤ typemax(n) ? pollardfactors!(n, h) : pollardfactors!(widen(n), h)
 end
 

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -272,7 +272,7 @@ function factor!(n::T, h::AbstractDict{K,Int}) where {T<:Integer,K<:Integer}
             end
         end
     end
-    isprime(n) && h[n]=1; return h
+    isprime(n) && (h[n]=1; return h)
     T <: BigInt || widemul(n - 1, n - 1) ≤ typemax(n) ? pollardfactors!(n, h) : pollardfactors!(widen(n), h)
 end
 


### PR DESCRIPTION
The theory here is that when the `factor` is used on a large number with many small factors, it ends up calling `isprime` about 5000 times. This is incredibly wasteful. For numbers where the `isprime` is true, this will still detect it relatively quickly. There is a 99.7% chance that this change will be less than 4 `mod` operations slower. As such, this is probably very slightly slower for factoring a small number times a massive prime, but much faster for everything else.