### PR TITLE
Fix ys in Pollard's rho algorithm

### DIFF
--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -411,8 +411,8 @@ function pollardfactors!(n::T, h::AbstractDict{K,Int}) where {T<:Integer,K<:Inte
             k::K = 0
             G = 1
             while k < r && G == 1
+                ys = y
                 for i in 1:(m > (r - k) ? (r - k) : m)
-                    ys = y
                     y = y^2 % n
                     y = (y + c) % n
                     q = (q * (x > y ? x - y : y - x)) % n

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -395,7 +395,7 @@ function pollardfactors!(n::T, h::AbstractDict{K,Int}) where {T<:Integer,K<:Inte
         G::T = 1
         r::K = 1
         y::T = rand(0:(n - 1))
-        m::K = 1900
+        m::K = 100
         ys::T = 0
         q::T = 1
         x::T = 0


### PR DESCRIPTION
I was using the Julia implementation of Pollard's rho algorithm as a reference and found the usage of `ys` to be strange: it turns out it doesn't match Brent's [paper](http://maths-people.anu.edu.au/~brent/pub/pub051.html) linked in the source (which does have the unusual style of placing the first statement in a `repeat` block on the same line as that keyword). See commit message for details. The high value of 1900 for `m` might need to be revisited with the corrected algorithm, as setting `ys` too often would have caused the last loop, bounded in size by `m`, to be effectively shortcut.