### PR TITLE
use `IntegerMathUtils`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,13 @@ version = "0.5.1"
 
 [extras]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+IntegerMathUtils = "18e54dd8-cb9d-406c-a71d-865a43cbb235"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DataStructures", "Test"]
+test = ["DataStructures", , "IntegerMathUtils", "Test"]
 
 [compat]
 DataStructures = "0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17"
+IntegerMathUtils = "0.1"
 julia = "1"

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ IntegerMathUtils = "18e54dd8-cb9d-406c-a71d-865a43cbb235"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["DataStructures", , "IntegerMathUtils", "Test"]
+test = ["DataStructures", "IntegerMathUtils", "Test"]
 
 [compat]
 DataStructures = "0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17"

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -177,7 +177,7 @@ julia> isprime(big(3))
 true
 ```
 """
-isprime(x::BigInt, reps=25) = is_probably_prime(x, reps)
+isprime(x::BigInt, reps=25) = is_probably_prime(x; reps=reps)
 
 # Miller-Rabin witness choices based on:
 #     http://mathoverflow.net/questions/101922/smallest-collection-of-bases-for-prime-testing-of-64-bit-numbers

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -7,6 +7,7 @@ using Base.Iterators: repeated
 import Base: iterate, eltype, IteratorSize, IteratorEltype
 using Base: BitSigned
 using Base.Checked: checked_neg
+using IntegerMathUtils
 
 export isprime, primes, primesmask, factor, ismersenneprime, isrieselprime,
        nextprime, nextprimes, prevprime, prevprimes, prime, prodfactors, radical, totient
@@ -176,11 +177,7 @@ julia> isprime(big(3))
 true
 ```
 """
-isprime(x::BigInt, reps=25) = ccall((:__gmpz_probab_prime_p,:libgmp),
-                                    Cint, (Any, Cint), x, reps) > 0
-# TODO: Change `Any` to `Ref{BigInt}` when 0.6 support is dropped.
-# The two have the same effect but `Ref{BigInt}` won't be optimized on 0.6.
-
+isprime(x::BigInt, reps=25) = is_probably_prime(x, reps)
 
 # Miller-Rabin witness choices based on:
 #     http://mathoverflow.net/questions/101922/smallest-collection-of-bases-for-prime-testing-of-64-bit-numbers


### PR DESCRIPTION
This PR adds a dependency on https://github.com/JuliaMath/IntegerMathUtils.jl which is a better place to put various integer functions (especially simple ones that wrap GMP). This PR as is doesn't make a ton of sense by itself, but it provides a good foundation for https://github.com/JuliaMath/Primes.jl/pull/104 and https://github.com/JuliaMath/Primes.jl/pull/102 which will want integer nth roots and Integer power checks (checking if `x=a^b` for `a`, `b` integers).