### PR TITLE
Use `===` over `==` to compare nothing in runtests.jl

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -261,7 +261,7 @@ for T = (Int, UInt, BigInt)
     @test f == d == Dict(f) == Factorization(d) == convert(Factorization, d)
     @test collect(f) == sort!(collect(d)) # test start/next/done
     @test length(f) == length(d)
-    @test get(f, T(101), nothing) == nothing
+    @test get(f, T(101), nothing) === nothing
     @test f[101] == 0
     @test f[0] == 0
     f[0] = 1


### PR DESCRIPTION
In the `@testset "Factorization{$T} as an AbstractDict" for T = (Int, UInt, BigInt)` section of `runtests.jl`, the comparison between
```julia
@test get(f, T(101), nothing)
```
and `nothing` should be with the triple equals sign operator, not the double equals sign operator.