### PR TITLE
Allow DataStructures v0.18

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 test = ["DataStructures", "IntegerMathUtils", "Test"]
 
 [compat]
-DataStructures = "0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17"
+DataStructures = "0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18"
 IntegerMathUtils = "0.1"
 julia = "1"


### PR DESCRIPTION
DataStructures.jl is a core package and v0.18 was released in Aug 17, 2020. This means that pretty much any package made after that won't be compatible with Primes.jl in its latest form, so this shows up as a major ecosystem update blocker. We should really make sure that this kind of repo has CompatHelper.jl on it.