### PR TITLE
use cached primes for fast `isprime` of small numbers

### DIFF
--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -147,7 +147,7 @@ function isprime(n::Integer)
     #     https://en.wikipedia.org/wiki/Miller–Rabin_primality_test
     #     https://github.com/JuliaLang/julia/issues/11594
     if n < PRIMES[end]
-        return n == searchsortedfirst(PRIMES, n)
+        return n == PRIMES[searchsortedfirst(PRIMES, n)]
     end
     for m in (2, 3, 5, 7, 11, 13, 17, 19, 23)
         n % m == 0 && return false

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -146,10 +146,12 @@ function isprime(n::Integer)
     # Small precomputed primes + Miller-Rabin for primality testing:
     #     https://en.wikipedia.org/wiki/Miller–Rabin_primality_test
     #     https://github.com/JuliaLang/julia/issues/11594
-    for m in (2, 3, 5, 7, 11, 13, 17, 19, 23)
-        n % m == 0 && return n == m
+    if n < PRIMES[end]
+        return n == searchsortedfirst(PRIMES, n)
     end
-    n < 841 && return n > 1
+    for m in (2, 3, 5, 7, 11, 13, 17, 19, 23)
+        n % m == 0 && return false
+    end
     s = trailing_zeros(n - 1)
     d = (n - 1) >>> s
     for a in witnesses(n)::Tuple{Vararg{Int}}


### PR DESCRIPTION
This reduces the time to 8ns from 250ns for `@btime isprime($(prevprime(2^16)))`. It's slightly slower for small non-primes (numbers with a smallest factor less than 13), but it means that for all small numbers, `isprime` will take very little time (less than 10ns)