### PR TITLE
switch `PRIMES` to `MIN_FACTOR`

### DIFF
--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -150,7 +150,7 @@ end
 
 # `MIN_FACTOR[i]` is `1` if `i` is `1` or prime
 # otherwise, `MIN_FACTOR[i]` is the first number which factors `i`
-const MIN_FACTOR = UInt8.(_min_factors(MIN_FACTOR_SIZE))
+const MIN_FACTOR = UInt8.(_min_factors(2^16))
 
 """
     isprime(n::Integer) -> Bool

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -166,7 +166,7 @@ function isprime(n::Integer)
     #     https://en.wikipedia.org/wiki/Miller–Rabin_primality_test
     #     https://github.com/JuliaLang/julia/issues/11594
     n < 2 && return false
-    trailing_zeros(n) > 1 && return n==2
+    trailing_zeros(n) > 0 && return n==2
     if n < N_SMALL_FACTORS
         return _min_factor(n) == 1
     end
@@ -276,7 +276,7 @@ function factor!(n::T, h::AbstractDict{K,Int}) where {T<:Integer,K<:Integer}
         increment!(h, tz, 2)
         n >>= tz
     end
-    if n <= N_SMALL_FACTORS 
+    if n <= N_SMALL_FACTORS
         while true
             n == 1 && return h
             if _min_factor(n)==1

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -269,9 +269,9 @@ function factor!(n::T, h::AbstractDict{K,Int}) where {T<:Integer,K<:Integer}
             return factor!(checked_neg(n), h)
         end
     elseif n == 0
-        h[n] = 0
+        h[n] = 1
         return h
-    elseif trailing_zeros(n) > 1
+    elseif trailing_zeros(n) > 0
         tz = trailing_zeros(n)
         increment!(h, tz, 2)
         n >>= tz

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -131,7 +131,7 @@ end
 primes(n::Int) = primes(1, n)
 
 # internal function for generating the minimum factor of a relatively small number
-funcion _min_factor(n)
+function _min_factor(n)
     n == 1 && return 1
     for i in 2:isqrt(n)
        n%i == 0 && return i

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -270,7 +270,7 @@ function factor!(n::T, h::AbstractDict{K,Int}) where {T<:Integer,K<:Integer}
     elseif n == 0
         h[n] = 1
         return h
-    elseif n <= MIN_FACTOR
+    elseif n <= length(MIN_FACTOR)
         while true
             n == 1 && return h
             if MIN_FACTOR[n]==1

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -56,7 +56,10 @@ function increment!(f::Factorization{T}, e::Int, p::Integer) where T
     end
     f
 end
-increment!(f::AbstractDict, e::Int, p::Integer) = (f[p] = get(f, p, 0) + e)
+function increment!(f::AbstractDict, e::Int, p::Integer)
+    f[p] = get(f, p, 0) + e
+    return f
+end
 
 Base.length(f::Factorization) = length(f.pe)
 


### PR DESCRIPTION
This caches the smallest factor for odd `n<2^16` (which is reasonable because this number can be stored in a `UInt8`, and therefore takes less space than `PRIMES` took before.

The advantage of storing this information rather than the (arguably more obvious) list of small primes is that it allows for O(1) primality testing as well as faster factoring. 
@jmichel7 can you test if this fixes your performance problems?