### PR TITLE
Divisors function

### DIFF
--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -34,4 +34,5 @@ Primes.primesmask
 ```@docs
 Primes.radical
 Primes.totient
+Primes.divisors
 ```

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -1,5 +1,4 @@
 # This file includes code that was formerly a part of Julia. License is MIT: http://julialang.org/license
-
 module Primes
 
 using Base.Iterators: repeated
@@ -9,7 +8,7 @@ using Base: BitSigned
 using Base.Checked: checked_neg
 using IntegerMathUtils
 
-export isprime, primes, primesmask, factor, eachfactor, ismersenneprime, isrieselprime,
+export isprime, primes, primesmask, factor, eachfactor, divisors, ismersenneprime, isrieselprime,
        nextprime, nextprimes, prevprime, prevprimes, prime, prodfactors, radical, totient
 
 include("factorization.jl")
@@ -907,5 +906,87 @@ julia> prevprimes(10, 10)
 """
 prevprimes(start::T, n::Integer) where {T<:Integer} =
     collect(T, Iterators.take(prevprimes(start), n))
+
+"""
+    divisors(n::T) -> Vector{T}
+
+Return a vector of all positive divisors of an integer `n`.
+
+For an integer `n` with prime factorization `n = p₁^k₁ ⋯ pₘ^kₘ`, `divisors(n)`
+returns a vector of length (k₁ + 1)⋯(kₘ + 1) containing the divisors of `n` in
+lexicographic (rather than numerical) order.
+
+```julia
+julia> divisors(60)
+12-element Vector{Int64}:
+  1      # 1
+  2      # 2
+  4      # 2 * 2
+  3      # 3
+  6      # 3 * 2
+ 12      # 3 * 2 * 2
+  5      # 5
+ 10      # 5 * 2
+ 20      # 5 * 2 * 2
+ 15      # 5 * 3
+ 30      # 5 * 3 * 2
+ 60      # 5 * 3 * 2 * 2
+```
+
+`divisors(-n)` is equivalent to `divisors(n)`.
+
+`divisors(0)` returns `[]`.
+"""
+function divisors(n::T)::Vector{T} where {T<:Integer}
+    if iszero(n)
+        return T[]
+    elseif isone(n)
+        return T[n]
+    elseif n < 0
+        return divisors(abs(n))
+    else
+        return divisors(factor(n))
+    end
+end
+
+"""
+    divisors(factors::Factorization{T}) -> Vector{T}
+
+Return a vector containing the divisors of the number described by `factors`. 
+Divisors are sorted lexicographically, rather than numerically.
+"""
+function divisors(factors::Primes.Factorization{T})::Vector{T} where {T<:Integer}
+    pe = factors.pe
+
+    if isempty(pe)
+        return T[one(T)] # n == 1
+    elseif pe[1][1] == 0 # n == 0
+        return T[]
+    elseif pe[1][1] == -1 # n < 0
+        if length(pe) == 1 # n == -1
+            return T[one(T)]
+        else
+            pe = pe[2:end]
+        end
+    end
+
+    i::Int = 1
+    m::Int = 1
+    divs = Vector{T}(undef, prod(x -> x.second + 1, pe))
+    divs[i] = one(T)
+
+    for (p, k) in pe
+        i = 1
+        for _ in 1:k
+            for j in i:(i+m-1)
+                divs[j+m] = divs[j] * p
+            end
+            i += m
+        end
+        m += i - 1
+    end
+
+    return divs
+end
 
 end # module

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -65,3 +65,5 @@ Base.length(f::Factorization) = length(f.pe)
 
 Base.show(io::IO, ::MIME{Symbol("text/plain")}, f::Factorization) =
     join(io, isempty(f) ? "1" : [(e == 1 ? "$p" : "$p^$e") for (p,e) in f.pe], " * ")
+
+Base.sign(f::Factorization) = isempty(f.pe) ? one(keytype(f)) : sign(first(f.pe[1]))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -236,6 +236,13 @@ end
 
 @test factor(1) == Dict{Int,Int}()
 
+# correctly return sign of factored numbers
+@test sign(factor(100)) == 1
+@test sign(factor(1)) == 1
+@test sign(factor(0)) == 0
+@test sign(factor(-1)) == -1
+@test sign(factor(-100)) == -1
+
 # factor returns a sorted dict
 @test all([issorted(collect(factor(rand(Int)))) for x in 1:100])
 
@@ -319,7 +326,7 @@ divisors_brute_force(n) = [d for d in one(n):n if iszero(n % d)]
 @testset "divisors(::$T)" for T in [Int16, Int32, Int64, BigInt]
     # 1 and 0 are handled specially
     @test divisors(one(T)) == divisors(-one(T)) == T[one(T)]
-    @test_throws ArgumentError @inferred(divisors(T(0)))
+    @test divisors(zero(T)) == T[]
 
     for n in 2:1000
         ds = divisors(T(n))
@@ -333,7 +340,7 @@ end
     # We just need to verify that the following cases are also handled correctly:
     @test divisors(factor(1)) == divisors(factor(-1)) == [1] # factorizations of 1 and -1
     @test divisors(factor(-56)) == divisors(factor(56)) == [1, 2, 4, 8, 7, 14, 28, 56] # factorizations of negative numbers
-    @test_throws ArgumentError @inferred(divisors(factor(0))) # factorizations of 0
+    @test isempty(divisors(factor(0)))
 end
 
 # check copy property for big primes relied upon in nextprime/prevprime

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -313,6 +313,29 @@ end
     end
 end
 
+# brute-force way to get divisors. Same elements as divisors(n), but order may differ.
+divisors_brute_force(n) = [d for d in one(n):n if iszero(n % d)]
+
+@testset "divisors(::$T)" for T in [Int16, Int32, Int64, BigInt]
+    # 1 and 0 are handled specially
+    @test divisors(one(T)) == divisors(-one(T)) == T[one(T)]
+    @test_throws ArgumentError @inferred(divisors(T(0)))
+
+    for n in 2:1000
+        ds = divisors(T(n))
+        @test ds == divisors(-T(n)) 
+        @test sort!(ds) == divisors_brute_force(T(n))
+    end
+end
+
+@testset "divisors(::Factorization)" begin
+    # divisors(n) calls divisors(factor(abs(n))), so the previous testset covers most cases.
+    # We just need to verify that the following cases are also handled correctly:
+    @test divisors(factor(1)) == divisors(factor(-1)) == [1] # factorizations of 1 and -1
+    @test divisors(factor(-56)) == divisors(factor(56)) == [1, 2, 4, 8, 7, 14, 28, 56] # factorizations of negative numbers
+    @test_throws ArgumentError @inferred(divisors(factor(0))) # factorizations of 0
+end
+
 # check copy property for big primes relied upon in nextprime/prevprime
 for n = rand(big(-10):big(10), 10)
     @test n+0 !== n


### PR DESCRIPTION
This PR introduces the function `divisors`, which takes an integer (or integer factorization), and returns a vector of its positive divisors. 

### Notes

#### Methods
The function has two methods: `divisors(n::T)::Vector{T} where {T<:Integer}`, and `divisors(f::Factorization{T})::Vector{T} where {T<:Integer}`. The former calls the latter directly. I played with the new `eachfactor` iterator looking for a more efficient technique in the integer case, but was ultimately unsuccessful. Knowing all prime exponents beforehand allows you to preallocate your output array, and it appears the performance benefits of doing so far outweigh the costs of creating a new `Factorization`.

#### Divisor sorting
As I've tried to make clear in its documentation, the output of this function is not numerically sorted. Instead, divisors come in lexicographic order:
$$n=p_1^{k_1} p_2^{k_2} \dots \mapsto (1, p_1, p_1^2, \dots, p_1^{k_1}, p_2, p_1 p_2, p_1^2 p_2, \dots, p_1^{k_1} p_2, p_2^2, \dots ).$$
The algorithm builds the array in this order, and I think returning it without sorting is a suitable design choice because it makes fewer assumptions about the user's purpose. Numerical order, if desired, can be readily obtained by calling `sort!`. Alternatively, `reshape(divisors(p1^k1 * p2^k2 * ... * pm^km), (k1 + 1, k2 + 1, ..., km + 1))` results in an `m`-dimensional array where dimension $i$ corresponds to powers of $p_i$—potentially a useful structure. For yet other uses (Dirichlet convolution comes to mind) order is irrelevant, and speed is the number one priority.

#### Zero
What should `divisors(0)` do? I throw an `ArgumentError`, same as `totient`, but perhaps it would be more convenient to quietly return an empty array?