### PR TITLE
suppressed Integer annotation on Factorization; fixed bug in calls of…

### DIFF
--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -966,7 +966,7 @@ end
 Return a vector with the positive divisors of the number whose factorization is `f`. 
 Divisors are sorted lexicographically, rather than numerically.
 """
-function divisors(f::Factorization{T}) where {T<:Integer}
+function divisors(f::Factorization{T}) where T
     sgn = sign(f)
     if iszero(sgn) # n == 0
         return T[]

--- a/src/factorization.jl
+++ b/src/factorization.jl
@@ -1,10 +1,10 @@
 # implementation of a sorted dict (not optimized for speed) for storing
 # the factorization of an integer
 
-struct Factorization{T<:Integer} <: AbstractDict{T, Int}
+struct Factorization{T} <: AbstractDict{T, Int}
     pe::Vector{Pair{T, Int}} # Prime-Exponent
 
-    function Factorization{T}() where {T<:Integer}
+    function Factorization{T}() where T
         # preallocates enough space that numbers smaller than 2310 won't need to resize
         v = Vector{Pair{T, Int}}(undef, 4)
         empty!(v)
@@ -12,26 +12,26 @@ struct Factorization{T<:Integer} <: AbstractDict{T, Int}
     end
 end
 
-function Factorization{T}(d::AbstractDict) where T<:Integer
+function Factorization{T}(d::AbstractDict) where T
     f = Factorization{T}()
     append!(f.pe, sort!(collect(d)))
     f
 end
 
-Factorization(d::AbstractDict{T}) where {T<:Integer} = Factorization{T}(d)
+Factorization(d::AbstractDict{T}) where T = Factorization{T}(d)
 Base.convert(::Type{Factorization}, d::AbstractDict) = Factorization(d)
 
 Base.iterate(f::Factorization, state...) = iterate(f.pe, state...)
 
 function Base.get(f::Factorization, p, default)
-    found = searchsortedfirst(f.pe, p, by=first)
+    found = searchsortedfirst(f.pe, p=>0, by=first)
     (found > length(f.pe) || first(f.pe[found])) != p  ? default : last(f.pe[found])
 end
 
-Base.getindex(f::Factorization, p::Integer) = get(f, p, 0)
+Base.getindex(f::Factorization, p) = get(f, p, 0)
 
-function Base.setindex!(f::Factorization{T}, e::Int, p::Integer) where T
-    found = searchsortedfirst(f.pe, p, by=first)
+function Base.setindex!(f::Factorization{T}, e::Int, p) where T
+    found = searchsortedfirst(f.pe, p=>0, by=first)
     if found > length(f.pe)
         push!(f.pe, T(p)=>e)
     elseif first(f.pe[found]) != p
@@ -45,8 +45,8 @@ end
 """
     impliments f[p] += e faster
 """
-function increment!(f::Factorization{T}, e::Int, p::Integer) where T
-    found = searchsortedfirst(f.pe, p, by=first)
+function increment!(f::Factorization{T}, e::Int, p) where T
+    found = searchsortedfirst(f.pe, p=>0, by=first)
     if found > length(f.pe)
         push!(f.pe, T(p)=>e)
     elseif first(f.pe[found]) != p
@@ -56,7 +56,7 @@ function increment!(f::Factorization{T}, e::Int, p::Integer) where T
     end
     f
 end
-function increment!(f::AbstractDict, e::Int, p::Integer)
+function increment!(f::AbstractDict, e::Int, p)
     f[p] = get(f, p, 0) + e
     return f
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -289,6 +289,17 @@ for T = (Int, UInt, BigInt)
     @test issorted(f.pe)
 end
 
+d = Dict(:a=>1,:b=>2)
+f = Factorization(d)
+@test f == d == Dict(f) == convert(Factorization, d)
+@test collect(f) == sort!(collect(d)) # test start/next/done
+@test length(f) == length(d)
+@test get(f, :c, nothing) === nothing
+@test f[:c] == 0
+@test f[:a] == 1
+f[:c] = 1
+@test get(f, :c, 0) == 1
+
 # dumb implementation of Euler totient for correctness tests
 ϕ(n) = count(m -> gcd(n, m) == 1, 1:n)
 


### PR DESCRIPTION
I suppressed the annotations `<:Integer` on the `T` of `Factorization`, allowing `Primes.Factorization` to be used to hold factorizations of other than integer (my goal is for polynomials). I added tests in `runtest.jl` where `T` is `Symbol`.
Along the way, I fixed bugs in the calls to `searchsortedfirst`. In the call `searchsortedfirst(f.pe, p, by=first)` contrary to intuition, the function `by` is applied to `p` so the proper second argument should be a pair. This does not show for `p` integer since then `first(p)==p` but it shows for other types. The fix is to give a pair:
 `searchsortedfirst(f.pe, p=>0, by=first)` 