### PR TITLE
Ensure doctests "see" the Primes module

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,5 +1,7 @@
 using Documenter, Primes
 
+DocMeta.setdocmeta!(Primes, :DocTestSetup, :(using Primes); recursive = true)
+
 makedocs(
     modules = [Primes],
     sitename = "Primes.jl",


### PR DESCRIPTION
OK, maybe it is as easy as this... we'll see (the failing doctests are visible in the CI logs, but do not actually cause a failures... but they do with PR #137)