### PR TITLE
Update title page of documentation

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,12 +4,10 @@ This package provides functions for computing prime numbers in Julia.
 
 ## Installation
 
-The package is available for Julia versions 0.4 and up, but if you are
-not using Julia version 0.7 or higher, please read the documentation for the
-appropriate realease.
+This release is available for Julia versions 1.6 and up.
 
 To install it, run
 ```julia
-Pkg.add("Primes")
+using Pkg ; Pkg.add("Primes")
 ```
 from the Julia REPL.


### PR DESCRIPTION
The install instructions were incomplete, and it seems pointless to mention Julia versions before 1.0.