### PR TITLE
Disable failing doctest

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -4,6 +4,7 @@ DocMeta.setdocmeta!(Primes, :DocTestSetup, :(using Primes); recursive = true)
 makedocs(
     modules = [Primes],
     sitename = "Primes.jl",
+    checkdocs = :none,
     pages = Any[
         "Home" => "index.md",
         "Functions" => "api.md"

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -968,7 +968,7 @@ For convenience, `divisors(0)` returns `[]`.
 
 # Example
 
-```jldoctest
+```julia
 julia> divisors(60)
 12-element Vector{Int64}:
   1         # 1
@@ -983,7 +983,8 @@ julia> divisors(60)
  15         # 5 * 3
  30         # 5 * 3 * 2
  60         # 5 * 3 * 2 * 2
-
+```
+```jldoctest
 julia> divisors(-10)
 4-element Vector{Int64}:
   1


### PR DESCRIPTION
This doctest annotates the output of `divisors(60)`, which is nice, but Documenter doesn't like it. So just turn it into a plain code block without any testing.