### PR TITLE
changed documentation of isprime(n::Integer) -> Bool

### DIFF
--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -156,8 +156,15 @@ end
 """
     isprime(n::Integer) -> Bool
 
-Returns `true` if `n` is prime, and `false` otherwise.
+Returns for INT64:  `true` if `n` is prime, and `false` otherwise 
+        for BigInt: `true` if `n` is probably prime, and `false` otherwise (false-positive rate = 0.25^reps with reps=25)
 
+    More detailed:
+    for even numbers: returns deterministic and correct results
+    for numbers in the INT 64 range: returns deterministic and correct results (by Lookup-tables, trial-division, Miller-Rabin, Lucas-Test)
+    for BigInt: returns probabilistic results by using Miller-Rabin from GNU Multiple Precision Arithmetic Library 
+                with reps=25, false-positive rate = 0.25^reps (considerered safe)
+    
 ```julia
 julia> isprime(3)
 true
@@ -290,6 +297,10 @@ end
 Probabilistic primality test. Returns `true` if `x` is prime with high probability (pseudoprime);
 and `false` if `x` is composite (not prime). The false positive rate is about `0.25^reps`.
 `reps = 25` is considered safe for cryptographic applications (Knuth, Seminumerical Algorithms).
+
+is_probably_prime is inherited from the module IntegerMathUtils that provides a wrapper to access
+functionality from the  GNU Multiple Precision Arithmetic Library (GMP) library, which performs a
+- Baillie-PSW probable prime test, then reps-24 Miller-Rabin probabilistic primality tests
 ```julia
 julia> isprime(big(3))
 true

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -156,14 +156,13 @@ end
 """
     isprime(n::Integer) -> Bool
 
-Returns for INT64:  `true` if `n` is prime, and `false` otherwise 
-        for BigInt: `true` if `n` is probably prime, and `false` otherwise (false-positive rate = 0.25^reps with reps=25)
+Returns for values in the range of an INT64 variable:  `true` if `n` is prime, and `false` otherwise 
+        for bigger values: `true` if `n` is probably prime, and `false` otherwise (false-positive rate = 0.25^reps with reps=25 --> considerered safe)
 
     More detailed:
     for even numbers: returns deterministic and correct results
-    for numbers in the INT 64 range: returns deterministic and correct results (by Lookup-tables, trial-division, Miller-Rabin, Lucas-Test)
-    for BigInt: returns probabilistic results by using Miller-Rabin from GNU Multiple Precision Arithmetic Library 
-                with reps=25, false-positive rate = 0.25^reps (considerered safe)
+    for values in the range of an  INT64 variable: returns deterministic and correct results (by Lookup-tables, trial-division, Miller-Rabin, Lucas-Test)
+    for bigger values: returns probabilistic resultsfrom GNU Multiple Precision Arithmetic Library 
     
 ```julia
 julia> isprime(3)
@@ -299,8 +298,7 @@ and `false` if `x` is composite (not prime). The false positive rate is about `0
 `reps = 25` is considered safe for cryptographic applications (Knuth, Seminumerical Algorithms).
 
 is_probably_prime is inherited from the module IntegerMathUtils that provides a wrapper to access
-functionality from the  GNU Multiple Precision Arithmetic Library (GMP) library, which performs a
-- Baillie-PSW probable prime test, then reps-24 Miller-Rabin probabilistic primality tests
+functionality from the  GNU Multiple Precision Arithmetic Library (GMP) library
 ```julia
 julia> isprime(big(3))
 true


### PR DESCRIPTION
- shows exactly when probabilistic methods are applied and when not
- mentions the used methods

changed documentation of isprime(x::BigInt, [reps = 25]) -> Bool
- stated where the function is_probably_prime comes from and explains what it does