### PR TITLE
Quadratic sieve factoring

### DIFF
--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -532,7 +532,7 @@ function QSfactor(n::T) where T
     # Generate factor base
     factor_base = [p for p in primes(B) if kronecker(n, p) == 1]
 
-    I = length(factor_base)#10*B # TODO: tune this
+    I = 10*B # TODO: tune this
     factored, smooth_nums, xs, relations = find_relations(n, factor_base, I)
     while !factored && length(xs) < length(factor_base) + 5
         I *= 2

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -474,7 +474,7 @@ function find_relations(n::T, factor_base, I) where T
     nf = Float64(n)
     sqrtnf = Float64(sqrtn)
     xsf = LinRange(sqrtnf-I, sqrtnf+I, 2I+1)
-    bound(i) = exponent(abs(fma(xsf[i], xsf[i], - nf)))
+    bound(i) = exponent(abs(max(fma(xsf[i], xsf[i], - nf), eps(nf))))
     sieve = Float64[bound(i) for i in 1:2I+1]
     # we can subtract lfb[end] since we know that we have checked for all smaller factors
     # this helps deal with the fact that we aren't sieving 2s or prime powers
@@ -541,7 +541,6 @@ function QSfactor(n::T) where T
     if factored
         return only(xs) - isqrt(only(smooth_nums))
     end
-    return
     # Gausian elimination
     rprime, marks, rrelations = gaussGF2(relations)
     


### PR DESCRIPTION
After being heavily nerd-sniped by @s-celles, here is a quadratic sieve implementation. It's already a good bit faster than my ECM implementation in https://github.com/JuliaMath/Primes.jl/pull/104 for semi-primes (and there still is some relatively low hanging fruit for further optimization, specifically looking for `x^2 - m*N` and using multiple polynomials). Unfortunately for factoring big numbers with lots of factors it's fairly slow (so probably needs combining with ECM with a low bound)

```
julia> x = prod(nextprime(big(2)^30, i) for i in 1:2)
1152921515344265237

julia> @time Primes.QSfactor(x)
  0.006857 seconds (25.64 k allocations: 1.795 MiB)

julia> x = prod(nextprime(big(2)^50, i) for i in 1:2)
1267650600228402790082356974917

julia> @time Primes.QSfactor(x)
  0.592893 seconds (353.31 k allocations: 55.101 MiB, 4.61% gc time)

julia> x = prod(nextprime(big(2)^30, i) for i in 1:4)
1329228037874877665163654221879315219

julia> @time Primes.QSfactor(x)
  5.168209 seconds (1.19 M allocations: 313.809 MiB, 0.56% gc time)
```
