### PR TITLE
ci: run ci on main branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
     tags: '*'
 jobs:
   test:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:
-          file: lcov.info
+          files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
 


### PR DESCRIPTION
- run ci on `main` branch rather master branch
	https://github.com/JuliaMath/Primes.jl/blob/23df5b343a7078f9a19f9449acd97ae56f269d8c/.github/workflows/CI.yml#L4-L6
- fix deprecated param (`file -> files`) for `codecov-action`

