### PR TITLE
Add yield to pollardfactor

### DIFF
--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -551,6 +551,7 @@ function pollardfactor(n::T) where {T<:Integer}
                 G = gcd(q, n)
                 k += m
             end
+            yield()
             r *= 2
         end
         G == n && (G = 1)


### PR DESCRIPTION
As per #167 adding yields allows `factor` and `pollardfactor` a scheduler to run when `factor` is wrapped in an `@task`. Adding a yield here means the execution can be monitored from time to time by the scheduling code.