### PR TITLE
Generic bigint `isprime` and minor generic cleanups

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,16 +4,15 @@ version = "0.5.7"
 
 [deps]
 IntegerMathUtils = "18e54dd8-cb9d-406c-a71d-865a43cbb235"
-Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
-
-[extras]
-IntegerMathUtils = "18e54dd8-cb9d-406c-a71d-865a43cbb235"
-DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-
-[targets]
-test = ["DataStructures", "IntegerMathUtils", "Test"]
 
 [compat]
 IntegerMathUtils = "0.1.1"
 julia = "1.6"
+
+[extras]
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+IntegerMathUtils = "18e54dd8-cb9d-406c-a71d-865a43cbb235"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["DataStructures", "IntegerMathUtils", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ version = "0.5.7"
 
 [deps]
 IntegerMathUtils = "18e54dd8-cb9d-406c-a71d-865a43cbb235"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [extras]
 IntegerMathUtils = "18e54dd8-cb9d-406c-a71d-865a43cbb235"

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -272,11 +272,8 @@ end
 # Requires n^2 + 2n < typemax(T)
 function lucas_test(n::T) where T<:Integer
     isqrt(n)^2 == n && return false
-    # Selfridge parameters: P = 1 and D the first of 5, -7, 9, -11, ... (magnitude
-    # d, sign s) with kronecker(D, n) == -1. Since d < n, the residues of D and of
-    # Q = (1-D)/4 mod n are just d/n-d and small shifts -- no division needed.
-    # countfrom keeps d an Int; iterating 5:2:n would make d unsigned and wrap on
-    # the sign flip.
+    # Selfridge parameters: P = 1 and
+    # D the first of 5, -7, 9, -11, ... with kronecker(D, n) == -1.
     local Dr::T, Q::T, kr
     for (s, d) in zip(Iterators.cycle((1, -1)), Iterators.countfrom(5, 2))
         Dr = s > 0 ? T(d) : n - T(d)               # D mod n

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -174,7 +174,7 @@ julia> isprime(4)
 false
 ```
 """
-function isprime(n::Integer, reps::Integer=25)
+function isprime(n::T, reps::Integer=25) where {T<:Integer}
     n ≤ typemax(Int64) && return isprime(Int64(n))
     # GMP-style probable-prime test in the operand's own arithmetic
     # BPSW, then reps - 24 extra Miller-Rabin rounds so
@@ -184,7 +184,12 @@ function isprime(n::Integer, reps::Integer=25)
         n % m == 0 && return false
     end
     miller_rabbin_test(2, n) || return false
-    lucas_test(n) || return false
+
+    if Base.hastypemax(T) && n >= isqrt(typemax(T))
+        lucas_test(widen(n)) || return false
+    else
+        lucas_test(n) || return false
+    end
     for _ in 1:max(reps - 24, 1)
         miller_rabbin_test(rand(3:n-2), n) || return false
     end
@@ -249,7 +254,7 @@ function _witnesses(n::UInt64)
     @inbounds return Int(bases[i])
 end
 
-function miller_rabbin_test(a, n::T) where T<:Signed
+function miller_rabbin_test(a, n::T) where T<:Integer
     s = trailing_zeros(n - 1)
     d = (n - 1) >>> s
     x::T = powermod(a, d, n)
@@ -264,32 +269,35 @@ function miller_rabbin_test(a, n::T) where T<:Signed
     return true
 end
 
-function lucas_test(n::T) where T<:Signed
-    Base.hastypemax(T) && @assert n <= isqrt(typemax(T))
-    s = isqrt(n)
-    s^2 == n && return false
-    # find Lucas test params
-    D::T = 5
-    for (s, d) in zip(Iterators.cycle((1,-1)), 5:2:n)
-        D = s*d
-        k = kronecker(D, n)
-        k != 1 && break
+# Requires n^2 + 2n < typemax(T)
+function lucas_test(n::T) where T<:Integer
+    isqrt(n)^2 == n && return false
+    # Selfridge parameters: P = 1 and D the first of 5, -7, 9, -11, ... (magnitude
+    # d, sign s) with kronecker(D, n) == -1. Since d < n, the residues of D and of
+    # Q = (1-D)/4 mod n are just d/n-d and small shifts -- no division needed.
+    # countfrom keeps d an Int; iterating 5:2:n would make d unsigned and wrap on
+    # the sign flip.
+    local Dr::T, Q::T, kr
+    for (s, d) in zip(Iterators.cycle((1, -1)), Iterators.countfrom(5, 2))
+        Dr = s > 0 ? T(d) : n - T(d)               # D mod n
+        Q  = s > 0 ? n - T((d - 1) >> 2) : T((d + 1) >> 2)  # (1-D)/4 mod n
+        kr = kronecker(Dr, n)
+        kr != 1 && break
     end
-    k == 0 && return false
-    # Lucas test with P=1
-    Q::T = (1-D) >> 2
+    kr == 0 && return false
     U::T, V::T, Qk::T = 1, 1, Q
-    k::T = (n + 1)
+    k::T = n + 1
     trail = trailing_zeros(k)
     k >>= trail
     # get digits 1 at a time since digits allocates
-    for b in ndigits(k,base=2)-2:-1:0
+    for b in ndigits(k, base=2)-2:-1:0
         U = mod(U*V, n)
-        V = mod(V * V - Qk - Qk, n)
-        Qk = mod(Qk*Qk, n)
-        if isodd(k>>b) == 1
-            Qk = mod(Qk*Q, n)
-            U, V = U + V, V + U*D
+        # V*V+2(n-Qk) rather than V*V-2*Qk to prevent Unsigned underflow
+        V = mod(V * V + 2*(n - Qk), n)
+        Qk = mod(Qk * Qk, n)
+        if isodd(k>>b)
+            Qk = mod(Qk * Q, n)
+            U, V = U + V, V + U*Dr
             # adding n makes them even
             # so we can divide by 2 without causing problems
             isodd(U) && (U += n)
@@ -298,12 +306,10 @@ function lucas_test(n::T) where T<:Signed
             V = mod(V >> 1, n)
         end
     end
-    if U in 0
-        return true
-    end
+    U == 0 && return true
     for _ in 1:trail
         V == 0 && return true
-        V = mod(V*V - Qk - Qk, n)
+        V = mod(V*V + 2*(n - Qk), n)
         Qk = mod(Qk * Qk, n)
     end
     return false

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -7,6 +7,7 @@ import Base: iterate, eltype, IteratorSize, IteratorEltype
 using Base: BitSigned
 using Base.Checked: checked_neg
 using IntegerMathUtils
+import Random
 
 export isprime, primes, primesmask, factor, eachfactor, divisors, ismersenneprime, isrieselprime,
        nextprime, nextprimes, prevprime, prevprimes, prime, prodfactors, radical, totient
@@ -174,9 +175,25 @@ julia> isprime(4)
 false
 ```
 """
-function isprime(n::Integer)
+# GMP-style probable-prime test in the operand's own arithmetic (BigInt has a
+# GMP-backed method and never reaches this). Like mpz_probab_prime_p in GMP
+# >= 6.2: trial division, BPSW, then reps - 24 extra Miller-Rabin rounds so
+# the error bound tracks GMP's for the same reps. The 4^-k Miller-Rabin bound
+# requires uniformly random bases; fixed base sets admit adversarial
+# composites (Arnault-style).
+function isprime(n::Integer, reps::Integer=25)
     n ≤ typemax(Int64) && return isprime(Int64(n))
-    return isprime(BigInt(n))
+    iseven(n) && return false
+    for m in (3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47)
+        n % m == 0 && return false
+    end
+    miller_rabbin_test(2, n) || return false
+    lucas_test(n) || return false
+    basesp = Random.Sampler(Random.default_rng(), oftype(n, 2):(n - 2))
+    for _ in 1:max(reps - 24, 1)
+        miller_rabbin_test(rand(Random.default_rng(), basesp), n) || return false
+    end
+    return true
 end
 
 # Uses a polyalgorithm depending on the size of n.
@@ -254,7 +271,8 @@ end
 
 function lucas_test(n::T) where T<:Signed
     s = isqrt(n)
-    @assert s <= typemax(T) #to prevent overflow
+    # overflow is only possible for fixed-width types
+    T <: Base.BitInteger && @assert s <= typemax(T)
     s^2 == n && return false
     # find Lucas test params
     D::T = 5
@@ -309,7 +327,7 @@ julia> isprime(big(3))
 true
 ```
 """
-isprime(x::BigInt, reps=25) = x>1 && is_probably_prime(x; reps=reps)
+isprime(x::BigInt, reps::Integer=25) = x>1 && is_probably_prime(x; reps=reps)
 
 struct FactorIterator{T<:Integer}
     n::T
@@ -392,7 +410,7 @@ function iterate(f::FactorIterator{T}, state=(f.n, T(3))) where T
     if n <= 2^32 || isprime(n)
         return (n, 1), (T(1), n)
     end
-    should_widen = T <: BigInt || widemul(n - 1, n - 1) ≤ typemax(n)
+    should_widen = !Base.hastypemax(T) || widemul(n - 1, n - 1) ≤ typemax(n)
     p = should_widen ? pollardfactor(n) : pollardfactor(widen(n))
     num_p = 0
     while true

--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -7,7 +7,6 @@ import Base: iterate, eltype, IteratorSize, IteratorEltype
 using Base: BitSigned
 using Base.Checked: checked_neg
 using IntegerMathUtils
-import Random
 
 export isprime, primes, primesmask, factor, eachfactor, divisors, ismersenneprime, isrieselprime,
        nextprime, nextprimes, prevprime, prevprimes, prime, prodfactors, radical, totient
@@ -175,23 +174,19 @@ julia> isprime(4)
 false
 ```
 """
-# GMP-style probable-prime test in the operand's own arithmetic (BigInt has a
-# GMP-backed method and never reaches this). Like mpz_probab_prime_p in GMP
-# >= 6.2: trial division, BPSW, then reps - 24 extra Miller-Rabin rounds so
-# the error bound tracks GMP's for the same reps. The 4^-k Miller-Rabin bound
-# requires uniformly random bases; fixed base sets admit adversarial
-# composites (Arnault-style).
 function isprime(n::Integer, reps::Integer=25)
     n ≤ typemax(Int64) && return isprime(Int64(n))
+    # GMP-style probable-prime test in the operand's own arithmetic
+    # BPSW, then reps - 24 extra Miller-Rabin rounds so
+    # the error bound tracks GMP's for the same reps.
     iseven(n) && return false
     for m in (3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47)
         n % m == 0 && return false
     end
     miller_rabbin_test(2, n) || return false
     lucas_test(n) || return false
-    basesp = Random.Sampler(Random.default_rng(), oftype(n, 2):(n - 2))
     for _ in 1:max(reps - 24, 1)
-        miller_rabbin_test(rand(Random.default_rng(), basesp), n) || return false
+        miller_rabbin_test(rand(3:n-2), n) || return false
     end
     return true
 end
@@ -270,9 +265,8 @@ function miller_rabbin_test(a, n::T) where T<:Signed
 end
 
 function lucas_test(n::T) where T<:Signed
+    Base.hastypemax(T) && @assert n <= isqrt(typemax(T))
     s = isqrt(n)
-    # overflow is only possible for fixed-width types
-    T <: Base.BitInteger && @assert s <= typemax(T)
     s^2 == n && return false
     # find Lucas test params
     D::T = 5


### PR DESCRIPTION
Rely less on BigInt for generic types. This enables other non Base Int types to be better supported by Primes.jl