### PR TITLE
Add `sieve_bound` to `SegmentedSieve`, Make `SegmentedSieve` generic, and narrow-window `eachprime`

### DIFF
--- a/src/Primes.jl
+++ b/src/Primes.jl
@@ -84,7 +84,10 @@ false
 ```
 """
 function isprime(n::T, reps::Integer=25) where {T<:Integer}
-    n ≤ typemax(Int64) && return isprime(Int64(n))
+    n < 2 && return false
+    # Everything below 2^64 uses the deterministic UInt64 path (hardware UInt128 arithmetic); for wider
+    # T (e.g. Int128) staying in T would make `widemul` widen to BigInt and allocate.
+    n ≤ typemax(UInt64) && return isprime(UInt64(n))
     # GMP-style probable-prime test in the operand's own arithmetic
     # BPSW, then reps - 24 extra Miller-Rabin rounds so
     # the error bound tracks GMP's for the same reps.
@@ -115,7 +118,7 @@ end
 # For more background on fast primality testing, see:
 #     http://ntheory.org/pseudoprimes.html
 #     http://ntheory.org/pseudoprimes.html
-function isprime(n::Int64)
+function isprime(n::UInt64)
     iseven(n) && return n == 2
     if n < N_SMALL_FACTORS
         n < 2 && return false
@@ -125,7 +128,7 @@ function isprime(n::Int64)
         n % m == 0 && return false
     end
     if n < 2^32
-        return miller_rabbin_test(_witnesses(UInt64(n)), n)
+        return miller_rabbin_test(_witnesses(n), n)
     end
     miller_rabbin_test(2, n) || return false
     return lucas_test(widen(n))

--- a/src/sieve.jl
+++ b/src/sieve.jl
@@ -182,7 +182,12 @@ function Base.iterate(ss::SegmentedSieve{T}, win_chunk::T = _first_chunk(ss.lo))
             pqT = T(pq)
             min_block = 30 * pqT * pqT + 2 * pqT * r + STRIDE_PSQ_DIV[pri] + (STRIDE_PSQ_RES[pri] > w)
             from_block = max(min_block, win_block)
-            start_block = from_block + mod(res_block - from_block, p)
+            # First block ≥ from_block that is ≡ res_block (mod p). res_block is the block of the smallest
+            # lane-w multiple p·STRIDE_KW, and STRIDE_KW < 30, so res_block < p. Stride primes are ≥ COMB_THRESH > 30,
+            # hence from_block ≥ min_block ≈ p²/30 ≥ p > res_block, so from_block - res_block never underflows; this
+            # is mod(res_block - from_block, p) rewritten to stay non-negative (correct for unsigned T too).
+            gap = (from_block - res_block) % p
+            start_block = gap == 0 ? from_block : from_block + (p - gap)
             local_start = Int(start_block - win_block)
             local_start < nblocks && stride_clear!(chunks, local_start, p, nblocks)
         end

--- a/src/sieve.jl
+++ b/src/sieve.jl
@@ -118,6 +118,7 @@ function SegmentedSieve(lo::T, hi::T; seg_chunks::Int = _seg_chunks(hi),
     max_prime = min(isqrt(hi), sieve_bound)
     max_prime ≤ 30 * (typemax(Int64) ÷ 256) || throw(ArgumentError("sieve_bound $max_prime exceeds the supported ceiling ~10^18."))
     if max_prime ≥ COMB_THRESH
+        sizehint!(stride_pack, floor(Int, max_prime / (log(max_prime) - 1.12)) - length(COMB_PRIMES)) # http://projecteuclid.org/euclid.rmjm/1181070157
         for p in eachprime(COMB_THRESH, Int(max_prime))
             pq, pr = divrem(p, 30)
             push!(stride_pack, 256 * pq + WHEEL_IDX[pr + 1])

--- a/src/sieve.jl
+++ b/src/sieve.jl
@@ -49,9 +49,8 @@ const COMB_TABLE   = NTuple{8,Vector{UInt64}}[build_combtab(p) for p in COMB_PRI
 
 # AND the lane against its period-p comb, realigned to the window's absolute phase so the
 # inner loop is a contiguous (vectorizable) slice-AND — no `%p` per chunk.
-@inline function comb_clear!(chunks::Vector{UInt64}, comb::Vector{UInt64}, p::Int, first_chunk::Int, nchunks::Int)
+@inline function comb_clear!(chunks::Vector{UInt64}, comb::Vector{UInt64}, p::Int, phase::Int, nchunks::Int)
     chunk = 1
-    phase = first_chunk % p
     @inbounds while chunk ≤ nchunks
         run = min(p - phase, nchunks - chunk + 1)
         @simd for j in 0:(run - 1)
@@ -88,61 +87,75 @@ consume those windows.
 
 2, 3, 5 are the caller's responsibility (the wheel skips them).
 """
-mutable struct SegmentedSieve
-    lo::Int
-    hi::Int
+mutable struct SegmentedSieve{T<:Integer}
+    win_block::T             # current window: first absolute block (block = value ÷ 30)
+    lo::T
+    hi::T
     seg_chunks::Int          # lane size (64-block chunks per window), so windows stay chunk-aligned
-    # Large base primes (≥ COMB_THRESH) as (p÷30, residue-class index); p and p² reconstruct from
-    # these, so the raw prime values are never stored. Small primes are the COMB_PRIMES const.
-    stride_primes::Vector{Tuple{Int32,Int8}}
+    # Large base primes (≥ COMB_THRESH) packed as 256·(p÷30) + wheel-index; p and p² reconstruct
+    # from these, so the raw prime values are never stored. Small primes are the COMB_PRIMES const.
+    # Sieving primes are bounded by feasibility (p ≲ 10^18), so this stays Int64 regardless of T.
+    stride_primes::Vector{Int64}
+    ncomb::Int               # active comb primes: COMB_PRIMES[1:ncomb] (those ≤ sieve_bound)
     lanes::Vector{BitVector} # the current window: 8 lanes, ≤ 64·seg_chunks bits each
-    win_block::Int           # current window: first absolute block
     nchunks::Int             # current window: number of valid chunks (padding bits are zeroed)
 end
 
 # Optimal number of chunks per window. Low cap is 32 KiB/lane allowing for sieving within L1.
 # As hi grows, we start sieving by bigger primes so we grow the window, but cap at MiB/lane to stay within L2.
-_seg_chunks(hi::Integer) = clamp(isqrt(hi) >>> 3, 1 << 12, 1 << 18)
+_seg_chunks(hi::Integer) = Int(clamp(isqrt(hi) >>> 3, 1 << 12, 1 << 18))  # clamp before narrowing
 
 # Chunk holding `lo` (window starts are chunk-aligned)
 _first_chunk(lo::Integer) = fld(lo, 30) >>> 6
 
-function SegmentedSieve(lo::Int, hi::Int; seg_chunks::Int = _seg_chunks(hi))
-    lo = max(7, lo)
-    # Decompose the stride primes (≥ COMB_THRESH; smaller ones are the comb) into (p÷30, residue
-    # class) once. Stream them with eachprime so we never allocate the full base-prime vector.
-    stride_primes = Tuple{Int32,Int8}[]
-    sq = isqrt(hi)
+# `sieve_bound` limits sieving to primes ≤ it: survivors are then the `sieve_bound`-rough numbers
+# in [lo, hi] (no prime factor ≤ sieve_bound), a superset of the primes. The default isqrt(hi)
+# gives an exact prime sieve. 2, 3, 5 are always the caller's responsibility (the wheel skips them).
+function SegmentedSieve(lo::T, hi::T; seg_chunks::Int = _seg_chunks(hi),
+                        sieve_bound::Integer = isqrt(hi)) where {T<:Integer}
+    lo = max(T(7), lo)
+    # Decompose the stride primes (≥ COMB_THRESH; smaller ones are the comb) into 256·(p÷30) +
+    # wheel-index once. Stream them with eachprime so we never allocate the full base-prime vector.
+    # The sieving-prime ceiling `sq` is small (a feasible sieve can't hold more base primes), so it
+    # fits Int even when the endpoints do not, and the packing bound below is far past any real sieve.
+    stride_primes = Int64[]
+    sqT = min(isqrt(hi), sieve_bound)
+    sqT ≤ 30 * (typemax(Int64) ÷ 256) ||
+        throw(ArgumentError("sieve_bound $sieve_bound exceeds the supported ceiling ~10^18"))
+    sq = Int(sqT)
     if sq ≥ COMB_THRESH
         for p in eachprime(COMB_THRESH, sq)
             pq, pr = divrem(p, 30)
-            push!(stride_primes, (pq % Int32, WHEEL_IDX[pr + 1] % Int8))
+            push!(stride_primes, 256 * pq + WHEEL_IDX[pr + 1])
         end
     end
-    num_chunks = min(seg_chunks, cld(fld(hi, 30) + 1, 64) - _first_chunk(lo))
+    ncomb = count(≤(sq), COMB_PRIMES)
+    num_chunks = Int(min(seg_chunks, cld(fld(hi, 30) + 1, 64) - _first_chunk(lo)))
     lanes = [BitVector(undef, num_chunks << 6) for _ in 1:8]
-    return SegmentedSieve(lo, hi, seg_chunks, stride_primes, lanes, 0, 0)
+    return SegmentedSieve{T}(zero(T), lo, hi, seg_chunks, stride_primes, ncomb, lanes, 0)
 end
 
-Base.IteratorSize(::Type{SegmentedSieve}) = Base.SizeUnknown()
-Base.eltype(::Type{SegmentedSieve}) = SegmentedSieve
+Base.IteratorSize(::Type{<:SegmentedSieve}) = Base.SizeUnknown()
+Base.eltype(::Type{S}) where {S<:SegmentedSieve} = S
 
 # Fill the next window into the lanes and yield the sieve itself (with `win_block`/`nchunks` set
 # to the current window). Boundary bits (< lo, > hi, padding) are masked, so consumers need
 # no per-prime range checks.
-function Base.iterate(ss::SegmentedSieve, win_chunk::Int = _first_chunk(ss.lo))
-    win_block = win_chunk << 6
+function Base.iterate(ss::SegmentedSieve{T}, win_chunk::T = _first_chunk(ss.lo)) where {T}
+    win_block = win_chunk << 6                         # absolute block (T); relative offsets below are Int
     last_block = fld(ss.hi, 30)
     win_block > last_block && return nothing
     lanes = ss.lanes
-    nblocks = min(ss.seg_chunks << 6, last_block - win_block + 1)
+    nblocks = Int(min(ss.seg_chunks << 6, last_block - win_block + 1))
     nchunks = cld(nblocks, 64)
     win_last_block = win_block + nblocks - 1
     win_max = win_last_block == last_block ? ss.hi : 30 * win_last_block + 29
-    max_prime = isqrt(win_max)
+    mp = isqrt(win_max)                                # cap the prime scan at √win_max, but never
+    max_prime = mp > typemax(Int) ? typemax(Int) : Int(mp)  # above Int (all stored primes fit Int)
 
     # Loop-invariant boundary conditions (applied per lane below to make consumers range-check-free).
-    lo_block, lo_res = divrem(ss.lo, 30)               # values < lo occupy blocks ≤ lo_block
+    lo_block = fld(ss.lo, 30)                          # values < lo occupy blocks ≤ lo_block
+    lo_res = Int(ss.lo - 30 * lo_block)                # lo % 30
     tail_local = last_block - win_block                # local block of hi (if hi falls in this window)
     hi_res = ss.hi - 30 * last_block                   # hi % 30, overflow-safe threshold
     tail_bits = nblocks - (nchunks - 1) * 64           # valid bits in the final chunk (64 ⇒ no padding)
@@ -153,41 +166,45 @@ function Base.iterate(ss::SegmentedSieve, win_chunk::Int = _first_chunk(ss.lo))
         chunks = lanes[lane].chunks
         fill!(chunks, ~UInt64(0))
         w = wheel[lane]
-        for ci in eachindex(COMB_PRIMES)               # small primes: periodic comb AND
+        for ci in 1:ss.ncomb                           # small primes ≤ sieve_bound: periodic comb AND
             p = COMB_PRIMES[ci]
             p > max_prime && break
-            comb_clear!(chunks, COMB_TABLE[ci][lane], p, win_chunk, nchunks)
+            comb_clear!(chunks, COMB_TABLE[ci][lane], p, Int(mod(win_chunk, p)), nchunks)
             if win_block == 0 && p % 30 == w           # comb cleared p's own bit (p·1) and this is p's lane
                 b = fld(p, 30)
                 chunks[b >>> 6 + 1] |= UInt64(1) << (b & 63)
             end
         end
-        for (pq32, pri) in ss.stride_primes            # large primes: scalar stride clear
+        for code in ss.stride_primes                   # large primes: scalar stride clear
             # Reconstruct p and p²÷30 from (pq, residue class) — no division. res_block is the phase:
             # lane-w multiples sit at blocks ≡ res_block (mod p). The only division left is mod p.
-            pq = Int(pq32)
+            pq, pri = fldmod(code, 256)
             r = wheel[pri]
             p = 30 * pq + r
             p > max_prime && break                     # primes are ascending; rest are too big for this window
             res_block = pq * STRIDE_KW[pri][lane] + STRIDE_C[pri][lane]
-            min_block = 30 * pq * pq + 2 * pq * r + STRIDE_PSQ_DIV[pri] + (STRIDE_PSQ_RES[pri] > w)
-            from_block = max(min_block, win_block)      # min_block = cld(p²-w, 30): first block ≥ p²
+            # min_block = cld(p²-w, 30): first block ≥ p². p² can exceed Int for large-T sieves, so
+            # this absolute block is computed in T; the relative `local_start` below is back in Int.
+            pqT = T(pq)
+            min_block = 30 * pqT * pqT + 2 * pqT * r + STRIDE_PSQ_DIV[pri] + (STRIDE_PSQ_RES[pri] > w)
+            from_block = max(min_block, win_block)
             start_block = from_block + mod(res_block - from_block, p)
-            local_start = start_block - win_block
+            local_start = Int(start_block - win_block)
             local_start < nblocks && stride_clear!(chunks, local_start, p, nblocks)
         end
         if win_block ≤ lo_block                        # first window: holds values < lo (incl. value 1)
             for block in win_block:(lo_block - 1)      # whole blocks below lo
-                loc = block - win_block
+                loc = Int(block - win_block)
                 chunks[loc >>> 6 + 1] &= ~(UInt64(1) << (loc & 63))
             end
             if w < lo_res                              # partial block holding lo
-                loc = lo_block - win_block
+                loc = Int(lo_block - win_block)
                 chunks[loc >>> 6 + 1] &= ~(UInt64(1) << (loc & 63))
             end
         end
         if tail_local < nblocks && w > hi_res          # clear values > hi in the tail block
-            chunks[tail_local >>> 6 + 1] &= ~(UInt64(1) << (tail_local & 63))
+            loc = Int(tail_local)
+            chunks[loc >>> 6 + 1] &= ~(UInt64(1) << (loc & 63))
         end
         if tail_bits < 64                              # zero the final chunk's padding
             chunks[nchunks] &= (UInt64(1) << tail_bits) - 1
@@ -236,8 +253,8 @@ end
 end
 
 # Call f(prime) for each prime in the filled window, in ascending order.
-function each_lane_prime(f, ss::SegmentedSieve)
-    win_block = ss.win_block
+function each_lane_prime(f, ss::SegmentedSieve{T}) where {T}
+    win_block = ss.win_block                                    # T; yielded values are T
     chunks = ntuple(i -> ss.lanes[i].chunks, Val(8))            # the 8 lanes' word arrays
     nchunks = ss.nchunks
     @inbounds for chunk in 1:nchunks
@@ -288,14 +305,15 @@ primesmask(n::Integer) = n ≤ typemax(Int) ? primesmask(Int(n)) :
 # Lazy prime stream over [lo, hi], backed by a SegmentedSieve.
 # Buffers one window's primes at a time (refilling on exhaustion); 2, 3, 5 are yielded first.
 # All iteration state lives in the (mutable) struct, so the iteration `state` is a dummy.
-mutable struct EachPrime
-    lo::Int
-    hi::Int
-    sieve::Union{SegmentedSieve,Nothing}  # nothing when hi < 7
-    next_chunk::Int                       # first chunk of the next window to fetch
-    buffer::Vector{Int}                   # the current window's primes
-    pos::Int                              # next index into buffer
-    phase::Int                            # 0,1,2 ⇒ emit 2,3,5; ≥3 ⇒ window mode
+mutable struct EachPrime{T<:Integer}
+    lo::T
+    hi::T
+    sieve::Union{SegmentedSieve{T},Nothing}  # nothing when hi < 7
+    next_chunk::T                            # first chunk of the next window to fetch
+    buffer::Vector{T}                        # the current window's primes
+    pos::Int                                 # next index into buffer
+    phase::Int                               # 0,1,2 ⇒ emit 2,3,5; ≥3 ⇒ window mode
+    verify::Bool                             # narrow window: sieve is rough, so isprime-filter survivors
 end
 
 """
@@ -305,19 +323,30 @@ Lazily iterate the primes in `[lo, hi]` (from 2 if `lo` is omitted) in increasin
 """
 function eachprime(lo::Integer, hi::Integer)
     lo ≤ hi || throw(ArgumentError("The condition lo ≤ hi must be met."))
-    lo, hi = Int(lo), Int(hi)
-    sieve = hi < 7 ? nothing : SegmentedSieve(max(7, lo), hi)
-    next_chunk = sieve === nothing ? 0 : _first_chunk(sieve.lo)
-    return EachPrime(lo, hi, sieve, next_chunk, Int[], 1, 0)
+    lo, hi = promote(lo, hi)
+    T = typeof(hi)
+    # Narrow window at large height: sieving all the way to √hi costs Θ(√hi) regardless of window
+    # width W. When W < √hi/150 it is cheaper to presieve only to k ≈ W (killing composites down to
+    # a small-factor floor) and BPSW-test the survivors — see docs/design/narrow-window-primes.md.
+    # In that regime the sieve yields W-rough numbers (a superset of primes), so we isprime-filter.
+    # A bound of W is the empirical optimum: below it, surviving composites (needing isprime) grow
+    # faster than the sieving saved; above it, sieving cost grows. The bowl is shallow near W.
+    sq = isqrt(hi)
+    W = hi - max(T(7), lo)
+    bound = W < sq ÷ 150 ? clamp(W, T(1000), sq) : sq
+    verify = bound < sq
+    sieve = hi < 7 ? nothing : SegmentedSieve(max(T(7), lo), hi; sieve_bound = bound)
+    next_chunk = sieve === nothing ? zero(T) : _first_chunk(sieve.lo)
+    return EachPrime{T}(lo, hi, sieve, next_chunk, T[], 1, 0, verify)
 end
 eachprime(hi::Integer) = eachprime(1, hi)
 
-Base.IteratorSize(::Type{EachPrime}) = Base.SizeUnknown()
-Base.eltype(::Type{EachPrime}) = Int
+Base.IteratorSize(::Type{<:EachPrime}) = Base.SizeUnknown()
+Base.eltype(::Type{EachPrime{T}}) where {T} = T
 
-function Base.iterate(ep::EachPrime, ::Any = nothing)
+function Base.iterate(ep::EachPrime{T}, ::Any = nothing) where {T}
     while ep.phase < 3                          # 2, 3, 5 precede every wheel prime
-        p = (2, 3, 5)[ep.phase + 1]
+        p = T((2, 3, 5)[ep.phase + 1])
         ep.phase += 1
         ep.lo ≤ p ≤ ep.hi && return (p, nothing)
     end
@@ -327,7 +356,11 @@ function Base.iterate(ep::EachPrime, ::Any = nothing)
         next === nothing && return nothing
         window, ep.next_chunk = next            # window === ep.sieve (it yields itself)
         empty!(ep.buffer)
-        each_lane_prime(v -> push!(ep.buffer, v), window)
+        if ep.verify                            # rough sieve: keep only the true primes among survivors
+            each_lane_prime(v -> (isprime(v) && push!(ep.buffer, v)), window)
+        else
+            each_lane_prime(v -> push!(ep.buffer, v), window)
+        end
         ep.pos = 1
     end
     p = ep.buffer[ep.pos]

--- a/src/sieve.jl
+++ b/src/sieve.jl
@@ -88,17 +88,14 @@ consume those windows.
 2, 3, 5 are the caller's responsibility (the wheel skips them).
 """
 mutable struct SegmentedSieve{T<:Integer}
-    win_block::T             # current window: first absolute block (block = value ÷ 30)
     lo::T
     hi::T
-    seg_chunks::Int          # lane size (64-block chunks per window), so windows stay chunk-aligned
-    # Large base primes (≥ COMB_THRESH) packed as 256·(p÷30) + wheel-index; p and p² reconstruct
-    # from these, so the raw prime values are never stored. Small primes are the COMB_PRIMES const.
-    # Sieving primes are bounded by feasibility (p ≲ 10^18), so this stays Int64 regardless of T.
-    stride_primes::Vector{Int64}
-    ncomb::Int               # active comb primes: COMB_PRIMES[1:ncomb] (those ≤ sieve_bound)
-    lanes::Vector{BitVector} # the current window: 8 lanes, ≤ 64·seg_chunks bits each
-    nchunks::Int             # current window: number of valid chunks (padding bits are zeroed)
+    win_block::T               # current window: first absolute block (block = value ÷ 30)
+    seg_chunks::Int            # lane size (64-block chunks per window), so windows stay chunk-aligned
+    stride_pack::Vector{Int64} # sieving primes (≥ COMB_THRESH) packed as 256·(p÷30) + wheel-index.
+    ncomb::Int                 # active comb primes: COMB_PRIMES[1:ncomb] (those ≤ sieve_bound)
+    lanes::Vector{BitVector}   # the current window: 8 lanes, ≤ 64·seg_chunks bits each
+    nchunks::Int               # current window: number of valid chunks (padding bits are zeroed)
 end
 
 # Optimal number of chunks per window. Low cap is 32 KiB/lane allowing for sieving within L1.
@@ -108,31 +105,28 @@ _seg_chunks(hi::Integer) = Int(clamp(isqrt(hi) >>> 3, 1 << 12, 1 << 18))  # clam
 # Chunk holding `lo` (window starts are chunk-aligned)
 _first_chunk(lo::Integer) = fld(lo, 30) >>> 6
 
-# `sieve_bound` limits sieving to primes ≤ it: survivors are then the `sieve_bound`-rough numbers
-# in [lo, hi] (no prime factor ≤ sieve_bound), a superset of the primes. The default isqrt(hi)
-# gives an exact prime sieve. 2, 3, 5 are always the caller's responsibility (the wheel skips them).
+# `sieve_bound > 5` limits sieving to return `sieve_bound`-rough numbers in [lo, hi] (no prime factor ≤ sieve_bound)
+# The default isqrt(hi) gives an exact prime sieve.
+# 2, 3, 5 are always the caller's responsibility (the wheel skips them).
 function SegmentedSieve(lo::T, hi::T; seg_chunks::Int = _seg_chunks(hi),
-                        sieve_bound::Integer = isqrt(hi)) where {T<:Integer}
+                        sieve_bound::Integer = typemax(Int)) where {T<:Integer}
     lo = max(T(7), lo)
-    # Decompose the stride primes (≥ COMB_THRESH; smaller ones are the comb) into 256·(p÷30) +
-    # wheel-index once. Stream them with eachprime so we never allocate the full base-prime vector.
-    # The sieving-prime ceiling `sq` is small (a feasible sieve can't hold more base primes), so it
-    # fits Int even when the endpoints do not, and the packing bound below is far past any real sieve.
-    stride_primes = Int64[]
-    sqT = min(isqrt(hi), sieve_bound)
-    sqT ≤ 30 * (typemax(Int64) ÷ 256) ||
-        throw(ArgumentError("sieve_bound $sieve_bound exceeds the supported ceiling ~10^18"))
-    sq = Int(sqT)
-    if sq ≥ COMB_THRESH
-        for p in eachprime(COMB_THRESH, sq)
+    # Decompose the stride primes (p<COMB_THRESH are in the comb) into 256·(p÷30) + wheel-index.
+    # Stream them with eachprime to limit allocation.
+    # The sieving-primes can be kept in Int64 because storing all primes < 2^64 would OOM anyway.
+    stride_pack = Int64[]
+    max_prime = min(isqrt(hi), sieve_bound)
+    max_prime ≤ 30 * (typemax(Int64) ÷ 256) || throw(ArgumentError("sieve_bound $max_prime exceeds the supported ceiling ~10^18."))
+    if max_prime ≥ COMB_THRESH
+        for p in eachprime(COMB_THRESH, Int(max_prime))
             pq, pr = divrem(p, 30)
-            push!(stride_primes, 256 * pq + WHEEL_IDX[pr + 1])
+            push!(stride_pack, 256 * pq + WHEEL_IDX[pr + 1])
         end
     end
-    ncomb = count(≤(sq), COMB_PRIMES)
+    ncomb = searchsortedlast(COMB_PRIMES, Int(max_prime))
     num_chunks = Int(min(seg_chunks, cld(fld(hi, 30) + 1, 64) - _first_chunk(lo)))
     lanes = [BitVector(undef, num_chunks << 6) for _ in 1:8]
-    return SegmentedSieve{T}(zero(T), lo, hi, seg_chunks, stride_primes, ncomb, lanes, 0)
+    return SegmentedSieve{T}(lo, hi, zero(T), seg_chunks, stride_pack, ncomb, lanes, 0)
 end
 
 Base.IteratorSize(::Type{<:SegmentedSieve}) = Base.SizeUnknown()
@@ -175,13 +169,13 @@ function Base.iterate(ss::SegmentedSieve{T}, win_chunk::T = _first_chunk(ss.lo))
                 chunks[b >>> 6 + 1] |= UInt64(1) << (b & 63)
             end
         end
-        for packed in ss.stride_primes                 # large primes: scalar stride clear
+        for packed in ss.stride_pack                    # large primes: scalar stride clear
             # Reconstruct p and p²÷30 from (pq, residue class) — no division. res_block is the phase:
             # lane-w multiples sit at blocks ≡ res_block (mod p). The only division left is mod p.
             pq, pri = packed >> 8, packed & 0xff        # packed = 256·(p÷30) + wheel-index, packed ≥ 0
             r = wheel[pri]
             p = 30 * pq + r
-            p > max_prime && break                     # primes are ascending; rest are too big for this window
+            p > max_prime && break                      # primes are ascending; rest are too big for this window
             res_block = pq * STRIDE_KW[pri][lane] + STRIDE_C[pri][lane]
             # min_block = cld(p²-w, 30): first block ≥ p². p² can exceed Int for large-T sieves, so
             # this absolute block is computed in T; the relative `local_start` below is back in Int.
@@ -253,8 +247,8 @@ end
 end
 
 # Call f(prime) for each prime in the filled window, in ascending order.
-function each_lane_prime(f, ss::SegmentedSieve{T}) where {T}
-    win_block = ss.win_block                                    # T; yielded values are T
+function each_lane_prime(f, ss::SegmentedSieve)
+    win_block = ss.win_block
     chunks = ntuple(i -> ss.lanes[i].chunks, Val(8))            # the 8 lanes' word arrays
     nchunks = ss.nchunks
     @inbounds for chunk in 1:nchunks
@@ -319,22 +313,21 @@ end
 """
     eachprime([lo,] hi)
 
-Lazily iterate the primes in `[lo, hi]` (from 2 if `lo` is omitted) in increasing order.
+Lazily iterate the primes in `[lo, hi]` (from 1 if `lo` is omitted) in increasing order.
 """
 function eachprime(lo::Integer, hi::Integer)
     lo ≤ hi || throw(ArgumentError("The condition lo ≤ hi must be met."))
     lo, hi = promote(lo, hi)
     T = typeof(hi)
-    # Narrow window at large height: sieving all the way to √hi costs Θ(√hi) regardless of window
-    # width W. When W < √hi/150 it is cheaper to presieve only to k ≈ W (killing composites down to
-    # a small-factor floor) and BPSW-test the survivors — see docs/design/narrow-window-primes.md.
-    # In that regime the sieve yields W-rough numbers (a superset of primes), so we isprime-filter.
-    # A bound of W is the empirical optimum: below it, surviving composites (needing isprime) grow
-    # faster than the sieving saved; above it, sieving cost grows. The bowl is shallow near W.
-    sq = isqrt(hi)
     W = hi - max(T(7), lo)
-    bound = W < sq ÷ 150 ? clamp(W, T(1000), sq) : sq
-    verify = bound < sq
+    # Sieving a window W by all primes < k costs O(k / log(k) + W * log(log(k)))
+    # sieving fully requres k = √hi, so When W << √hi, we can instead 
+    # sieve to a lower k and primality check survivors.
+    # By sieving to k leaves O(W / log(k)) survivors, so primality check costs O(W * log^2(hi) / log(k))
+    # Thus setting k=W, gives a cost of O(W / log(W) * log^2(hi) + W * log(log(W))) << O(√hi)
+    sqrthi = isqrt(hi)
+    bound = 1000 < W < sqrthi ÷ 150 ? W : sqrthi
+    verify = bound < sqrthi
     sieve = hi < 7 ? nothing : SegmentedSieve(max(T(7), lo), hi; sieve_bound = bound)
     next_chunk = sieve === nothing ? zero(T) : _first_chunk(sieve.lo)
     return EachPrime{T}(lo, hi, sieve, next_chunk, T[], 1, 0, verify)

--- a/src/sieve.jl
+++ b/src/sieve.jl
@@ -175,10 +175,10 @@ function Base.iterate(ss::SegmentedSieve{T}, win_chunk::T = _first_chunk(ss.lo))
                 chunks[b >>> 6 + 1] |= UInt64(1) << (b & 63)
             end
         end
-        for code in ss.stride_primes                   # large primes: scalar stride clear
+        for packed in ss.stride_primes                 # large primes: scalar stride clear
             # Reconstruct p and p²÷30 from (pq, residue class) — no division. res_block is the phase:
             # lane-w multiples sit at blocks ≡ res_block (mod p). The only division left is mod p.
-            pq, pri = fldmod(code, 256)
+            pq, pri = packed >> 8, packed & 0xff        # packed = 256·(p÷30) + wheel-index, packed ≥ 0
             r = wheel[pri]
             p = 30 * pq + r
             p > max_prime && break                     # primes are ascending; rest are too big for this window

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -137,6 +137,20 @@ for lo in (Int128(10)^30, big(10)^40)
     @test got == [n for n in lo:hi if isprime(n)]
 end
 
+# Unsigned windows above typemax(Int64): the block-phase offset must not underflow (it once did,
+# silently mis-sieving). Every integer type over the same range must yield identical primes.
+let W = 10^6
+    for lo in (UInt(10)^19, UInt(2)^63 + 1)
+        hi = lo + W
+        ref = collect(eachprime(Int128(lo), Int128(hi)))
+        for T in (UInt64, UInt128, Int128)
+            got = collect(eachprime(T(lo), T(hi)))
+            @test eltype(got) === T
+            @test got == ref
+        end
+    end
+end
+
 # sieve_bound: survivors are the B-rough numbers (no prime factor ≤ B), a superset of the primes.
 let
     rough(lo, hi, B) = (out = Int[];
@@ -198,6 +212,16 @@ end
 for T in [Int8, UInt8, Int16, UInt16, Int128, UInt128]
     @test isprime(T(2))
     @test !isprime(T(4))
+end
+
+# Values in (2^63, 2^64) are deterministic via the UInt64 path; wider types must narrow to it and
+# agree (and not allocate — for Int128 that means avoiding a BigInt-widening `widemul`).
+let p = 0xffffffffffffffc5, c = 0xffffffffffffffc7   # a prime and a composite just below 2^64
+    for T in (UInt64, Int128, UInt128, BigInt)
+        @test isprime(T(p))
+        @test !isprime(T(c))
+    end
+    @test (@allocated isprime(Int128(p))) == 0
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -121,6 +121,38 @@ for seg_chunks in (1, 3, 7)
     @test ps == primes(7, 300_000)
 end
 
+# Narrow windows at large heights presieve to ~4W and isprime-filter survivors (rough sieve),
+# rather than sieving to isqrt(hi); the yielded primes must still be exactly correct.
+for (lo, W) in ((10^18, 1000), (10^15, 5000), (2 * 10^12, 2000), (10^9, 300))
+    hi = lo + W
+    @test collect(eachprime(lo, hi)) == [n for n in lo:hi if isprime(n)]
+end
+
+# eachprime/SegmentedSieve are generic over the integer type: narrow windows at heights beyond
+# Int64 (Int128, BigInt) sieve to ~W and isprime-filter, and must yield the correct typed primes.
+for lo in (Int128(10)^30, big(10)^40)
+    hi = lo + 3000
+    got = collect(eachprime(lo, hi))
+    @test eltype(got) === typeof(lo)
+    @test got == [n for n in lo:hi if isprime(n)]
+end
+
+# sieve_bound: survivors are the B-rough numbers (no prime factor ≤ B), a superset of the primes.
+let
+    rough(lo, hi, B) = (out = Int[];
+        for ss in Primes.SegmentedSieve(max(7, lo), hi; sieve_bound = B)
+            Primes.each_lane_prime(p -> push!(out, p), ss)
+        end; out)
+    oracle(lo, hi, B) = [v for v in max(7, lo):hi if all(v % p != 0 for p in primes(B))]
+    for (lo, hi, B) in ((10^6, 10^6 + 10^5, 50),          # B < COMB_THRESH
+                        (10^6, 10^6 + 10^5, 1000),        # COMB_THRESH ≤ B < isqrt(hi)
+                        (10^7, 10^7 + 3 * 10^5, 137))     # multi-window
+        @test rough(lo, hi, B) == oracle(lo, hi, B)
+    end
+    # B ≥ isqrt(hi) is an exact prime sieve, matching the default.
+    @test rough(10^6, 10^6 + 10^5, isqrt(10^6 + 10^5)) == primes(10^6, 10^6 + 10^5)
+end
+
 for T in [Int, BigInt], n = [1:1000;1000000]
     n = convert(T, n)
     f = factor(n)


### PR DESCRIPTION
This is a 4 small but nice improvements to the newly added `SegmentedSieve` and `eachprime`.

1. Add `sieve_bound` to `SegmentedSieve` for B-rough sieving (survivors have no prime factor <= B); default isqrt(hi) preserves the exact prime sieve.
2. Pack `stride_primes` into `Vector{Int64}`, stored as (`256*(p/30)+wheel_index`). This allows sieving by primes up to 
3. Parametrize `SegmentedSieve{T}`/EachPrime{T} over the integer type to allow `Int128`/`BigInt heights (note that this will only work for sieving up to a .  Per-bit offsets stay Int; T arithmetic is confined to O(pi(bound))/window sites.
4. eachprime uses a narrow-window strategy: When `hi-lo < sqrt(hi)/150` it sieves only by primes `p < hi-lo` and uses `isprime` to ensure it only returns primes. This is much faster and lowers memory for `eachprime` from `O(sqrt(hi) + hi-lo)` to `O(min(sqrt(hi), (hi-lo) * ln(ln(hi)) ))`.

Benchmarks:
```
julia> @time sum(eachprime(10^18, 10^18+10^5));
  1.606364 seconds (336 allocations: 1.317 GiB)   # before
  0.004651 seconds (123 allocations: 323.164 KiB) # after

julia> @time sum(eachprime(10^18, 10^18+10^6))
  1.642741 seconds (350 allocations: 1.317 GiB)   # before 
  0.042451 seconds (152 allocations: 2.750 MiB)   # after

julia> @time sum(eachprime(10^18, 10^18+10^7));
  1.650434 seconds (358 allocations: 1.322 GiB)   # before
  1.086680 seconds (304 allocations: 411.965 MiB) # after
```

Coauthored by claude.